### PR TITLE
Fix: clear robot path and distance when unassigning task

### DIFF
--- a/hvbta/allocators/misc_assignment.py
+++ b/hvbta/allocators/misc_assignment.py
@@ -48,7 +48,9 @@ def unassign_task_from_robot(robot: CapabilityProfile, task: TaskDescription, un
         unassigned_tasks.append(tid)
     # unassign robot
     robot.current_task = None
-    # move it to unassigned robots list with check
+    robot.current_path = []
+    robot.remaining_distance = 0
+# move it to unassigned robots list with check
     rid = robot.robot_id
     if rid not in unassigned_robots:
         unassigned_robots.append(rid)


### PR DESCRIPTION
Fixes bug where a robot could continue following its old path after being unassigned.
Added:
- robot.current_path = []
- robot.remaining_distance = 0
This makes sure that the robot stops moving immediately after unassignment.