### PR TITLE
Clean up idle_steps after robot removal

### DIFF
--- a/hvbta/allocators/misc_assignment.py
+++ b/hvbta/allocators/misc_assignment.py
@@ -237,9 +237,11 @@ def remove_random_robots(robots: List[CapabilityProfile], tasks: List[TaskDescri
         goal_positions: A dictionary mapping robot IDs to their goal positions.
         
     Returns:
-        None
+        List of robots that were removed.
     """    
     robots_to_remove = random.sample(robots, min(count, len(robots) - 1))  # Make sure theres always at least one robot so CBS doesnt break
+    removed_robots = [] #stores and keeps track of every robot that gets removed during the function
+
 
     for robot_to_remove in robots_to_remove:
         occupied_locations.discard(robot_to_remove.location)
@@ -265,3 +267,5 @@ def remove_random_robots(robots: List[CapabilityProfile], tasks: List[TaskDescri
                 unassigned_robots.remove(robot_to_remove.robot_id)
         robots.remove(robot_to_remove)
 #         print(f"Robot {robot_to_remove.robot_id} left the system. It attempted {robot_to_remove.tasks_attempted} tasks and successfully completed {robot_to_remove.tasks_successful} of them.")
+        removed_robots.append(robot_to_remove)  #Track removed robot so caller can clean up idle_steps
+    return removed_robots #Return removed robots so callers can clean up related state

--- a/hvbta/simulation/main_sim_no_CBS.py
+++ b/hvbta/simulation/main_sim_no_CBS.py
@@ -350,7 +350,11 @@ def main_simulation(
         if remove_robots and time_step + 1 <= 4 and random.random() < 0.5: # remove robots only in the first 4 time steps, and randomly
             if len(assigned_robots) > 1: # Otherwise will break CBS, we need at least one agent for things to run smoothly
                 print(f"REMOVING RANDOM ROBOTS AT TIME STEP {time_step + 1}")
-                remove_random_robots(robots, tasks, unassigned_robots, unassigned_tasks, random.randint(0, robots_to_remove), occupied_positions, start_positions, goal_positions)
+                # Keeps track of which robots were removed so their idle state can be cleaned up
+                removed_robots = remove_random_robots(robots, tasks, unassigned_robots, unassigned_tasks, random.randint(0, robots_to_remove), occupied_positions, start_positions, goal_positions) # Keep track of which robots were removed so their idle state can be cleaned up
+                # Remove stale idle_steps entries for robots that are no longer in the simulation
+                for removed_robot in removed_robots:
+                    idle_steps.pop(removed_robot.robot_id, None)
 
         for r in robots:
             if not r.assigned:

--- a/hvbta/simulation/main_simulation.py
+++ b/hvbta/simulation/main_simulation.py
@@ -255,8 +255,11 @@ def main_simulation(
         if remove_robots and time_step + 1 <= 4 and random.random() < 0.5: # remove robots only in the first 4 time steps, and randomly
             if len(assigned_robots) > 1: # Otherwise will break CBS, we need at least one agent for things to run smoothly
                 print(f"REMOVING RANDOM ROBOTS AT TIME STEP {time_step + 1}")
-                remove_random_robots(robots, tasks, unassigned_robots, unassigned_tasks, random.randint(0, robots_to_remove), occupied_positions, start_positions, goal_positions)
-
+                # Keeps track of which robots were removed so their idle state can be cleaned up
+                removed_robots = remove_random_robots(robots, tasks, unassigned_robots, unassigned_tasks, random.randint(0, robots_to_remove), occupied_positions, start_positions, goal_positions)
+                # Remove stale idle_steps entries for robots that are no longer in the simulation
+                for removed_robot in removed_robots: 
+                    idle_steps.pop(removed_robot.robot_id, None) 
         # print(f"DEBUG STATEMENT 11")
 
         for r in robots:


### PR DESCRIPTION
This PR fixes bug10 by cleaning up stale idle_steps entries when robots are removed from the simulation.
Changes:
-Updated remove_random_robots() to return the list of removed robots
-Updated main_simulation.py to remove deleted robot IDs from idle_steps
-Updated main_sim_no_CBS.py to do the same cleanup in the no-CBS simulation.

Ran py_compile on:
-allocators/misc_assignment.py
-simulation/main_simulation.py
-simulation/main_sim_no_CBS.py
no syntax errors were found