### PR TITLE
Fix robot removal guard condition

### DIFF
--- a/hvbta/simulation/main_sim_no_CBS.py
+++ b/hvbta/simulation/main_sim_no_CBS.py
@@ -348,7 +348,7 @@ def main_simulation(
 
         # Periodically remove robots
         if remove_robots and time_step + 1 <= 4 and random.random() < 0.5: # remove robots only in the first 4 time steps, and randomly
-            if len(assigned_robots) > 1: # Otherwise will break CBS, we need at least one agent for things to run smoothly
+            if len(robots) > 1: # Ensure at least one robot remains in the simulation
                 print(f"REMOVING RANDOM ROBOTS AT TIME STEP {time_step + 1}")
                 remove_random_robots(robots, tasks, unassigned_robots, unassigned_tasks, random.randint(0, robots_to_remove), occupied_positions, start_positions, goal_positions)
 

--- a/hvbta/simulation/main_simulation.py
+++ b/hvbta/simulation/main_simulation.py
@@ -253,7 +253,7 @@ def main_simulation(
 
         # Periodically remove robots
         if remove_robots and time_step + 1 <= 4 and random.random() < 0.5: # remove robots only in the first 4 time steps, and randomly
-            if len(assigned_robots) > 1: # Otherwise will break CBS, we need at least one agent for things to run smoothly
+            if len(robots) > 1: # Ensure at least one robot remains in the simulation
                 print(f"REMOVING RANDOM ROBOTS AT TIME STEP {time_step + 1}")
                 remove_random_robots(robots, tasks, unassigned_robots, unassigned_tasks, random.randint(0, robots_to_remove), occupied_positions, start_positions, goal_positions)
 


### PR DESCRIPTION
Fixes bug #14 by changing the robot removal guard to check the total number of robots instead of only assigned robots.
Changes
- Updated main_simulation.py to use len(robots) > 1 before removing robots.
- Updated main_sim_no_CBS.py with the same guard change.