### PR TITLE
Relax should_replan guard for dynamic events

### DIFF
--- a/hvbta/simulation/main_simulation.py
+++ b/hvbta/simulation/main_simulation.py
@@ -285,7 +285,8 @@ def main_simulation(
 
         # decide to reassign and replan
         should_replan = False
-        if unassigned_robots and unassigned_tasks:
+        # Allow replanning when either side changes, including dynamic task or robot arrivals
+        if unassigned_robots or unassigned_tasks or events["new_tasks"] or events["new_robots"]:
             if events["new_tasks"] or events["new_robots"] or events["completed_tasks"]:
                 should_replan = True
             elif (current_active != previous_active) or (current_goals != previous_goals):


### PR DESCRIPTION
summary: fixes bug #6 by relaxing the reassignment guard so replanning can run when unassigned robots, unassigned tasks, or dynamic task/robot events are present.

- changed the reassignment guard in main_simulation.py from requiring both unassigned_robots and unassigned_tasks to allowing either list or new task/robot events. This lets the simulation recheck robot-task assignments when new tasks or robots are added.
