### PR TITLE
Remove unused is_solution stub (bug #16) 

### DIFF
--- a/hvbta/pathfinding/Final_CBS.py
+++ b/hvbta/pathfinding/Final_CBS.py
@@ -316,8 +316,6 @@ class Environment(object):
         """
         return EdgeConstraint(state_1.time, state_1.location, state_2.location) not in self.constraints.edge_constraints
 
-    def is_solution(self, agent_name):
-        pass
 
     def admissible_heuristic(self, state: State, agent_name: str) -> float:
         """


### PR DESCRIPTION
Summary: Removes the unused empty is_solution() stub from Final_CBS.py

Changes
- Removed the is_solution() method because it only contained pass
- Confirmed it was not used anywhere else in the repository.