### PR TITLE
Update simulation and direct assignment

### DIFF
--- a/hvbta/allocators/optimizers.py
+++ b/hvbta/allocators/optimizers.py
@@ -217,6 +217,7 @@ def assign_tasks_with_method(
     
     # Extract per-agent scores for fairness calculation (only assigned agents)
     per_agent_scores = [float(suitability_matrix[r][t]) for r, t in assignment]
+    print(f"Best assignment in optimization {assignment}")
     
     return (assignment, unassigned_robots, unassigned_tasks), total_score, allocation_time, per_agent_scores
 
@@ -266,7 +267,7 @@ def assign_tasks_with_method_randomly(
     unassigned_robots = []
     unassigned_tasks = []
 
-    print(f"\n\n\n\nPAIRS: {final_pairs} \n\n\n\n UNR: {final_unr_idx} \n\n\n\n UNT: {final_unt_idx}\n\n\n\n")
+    print(f"ASSIGNED PAIRS: {final_pairs} \n UNASSIGNED ROBOTS: {final_unr_idx} \n UNASSIGNED TASKS: {final_unt_idx}")
     for robot_id, task_id in final_pairs:
         assigned_pairs.append((robot_id, task_id))
 
@@ -281,7 +282,7 @@ def assign_tasks_with_method_randomly(
 
     filtered_best_assignments = (assigned_pairs, unassigned_robots, unassigned_tasks)
 
-    print(f"Best assignment in optimization: {filtered_best_assignments}")
+    # print(f"Best assignment in optimization: {filtered_best_assignments}")
     
     # Per-agent scores are all 0.0 for random assignment (all-zero suitability case)
     per_agent_scores = [0.0] * len(assigned_pairs)
@@ -482,7 +483,7 @@ def reassign_robots_to_tasks_randomly_with_method(
     unassigned_robots = []
     unassigned_tasks = []
 
-    print(f"\n\n\n\nPAIRS: {final_pairs} \n\n\n\n UNR: {final_unr_idx} \n\n\n\n UNT: {final_unt_idx}\n\n\n\n")
+    print(f"ASSIGNED PAIRS: {final_pairs} \n UNASSIGNED ROBOTS: {final_unr_idx} \n UNASSIGNED TASKS: {final_unt_idx}")
 
     for robot_id, task_id in final_pairs:
         assigned_pairs.append((robot_id, task_id))

--- a/hvbta/allocators/voting.py
+++ b/hvbta/allocators/voting.py
@@ -397,7 +397,7 @@ def assign_tasks_randomly(
     unassigned_robots = []
     unassigned_tasks = []
 
-    print(f"\n\n\n\nPAIRS: {final_pairs} \n\n\n\n UNR: {final_unr_idx} \n\n\n\n UNT: {final_unt_idx}\n\n\n\n")
+    print(f"ASSIGNED PAIRS: {final_pairs} \n UNASSIGNED ROBOTS: {final_unr_idx} \n UNASSIGNED TASKS: {final_unt_idx}")
 
     for robot_id, task_id in final_pairs:
         assigned_pairs.append((robot_id, task_id))
@@ -556,7 +556,7 @@ def reassign_robots_to_tasks(
                 if best.robot_id in unassigned_robots:
                     unassigned_robots.remove(best.robot_id)
     
-    # print(f"Reassign Score: {score}, Reassign Length: {length}")
+    print(f"Reassign Score: {score}, Reassign Length: {length}")
 
     # Recalculate per_agent_scores after potential stealing - get scores for all assigned robots
     final_per_agent_scores = []
@@ -619,7 +619,7 @@ def reassign_robots_to_tasks_randomly(
     unassigned_robots = []
     unassigned_tasks = []
 
-    print(f"\n\n\n\nPAIRS: {final_pairs} \n\n\n\n UNR: {final_unr_idx} \n\n\n\n UNT: {final_unt_idx}\n\n\n\n")
+    print(f"ASSIGNED PAIRS: {final_pairs} \n UNASSIGNED ROBOTS: {final_unr_idx} \n UNASSIGNED TASKS: {final_unt_idx}")
 
     for robot_id, task_id in final_pairs:
         assigned_pairs.append((robot_id, task_id))

--- a/hvbta/generation.py
+++ b/hvbta/generation.py
@@ -19,29 +19,51 @@ def _sample(items: List[str], k_min: int = 0, k_max: int = None) -> List[str]:
     k = random.randint(k_min, k_max)
     return random.sample(items, k)
 
-def get_unique_task_location(tasks, grid, occupied_locations, max_attempts=100):
+def get_unique_task_location(tasks, grid, occupied_locations=None, max_attempts=100):
     """
-    Finds a unique location for a new task that does not overlap with existing tasks or occupied robot locations.
-    Occupied locations only include robot locations, not task locations so we check both with this function.
+    Spawn rule: no two task locations may overlap, but a task may share a cell with a robot.
     Args:
         tasks: List of existing TaskDescription objects to check against.
         grid: The grid representing the environment, used to find free positions.
-        occupied_locations: A set of tuples representing locations occupied by robots.
-        max_attempts: Maximum number of attempts to find a unique location before giving up.
+        occupied_locations: Ignored for the overlap check (kept for backward-compat); only
+            other-task locations are forbidden.
+        max_attempts: Maximum number of attempts before giving up.
 
     Returns:
         location: A unique (x, y, z) location tuple for the new task.
     """
-    attempts = 0
     task_locations = {task.location for task in tasks}
-    all_occupied_locations = occupied_locations | task_locations  # Combine occupied locations with existing task locations
-    location = get_random_free_position(grid, all_occupied_locations)
-    # Ensure the location is unique and not occupied by any robot or existing task
-    while any(np.allclose(location, occ_loc) for occ_loc in all_occupied_locations):
+    location = get_random_free_position(grid, task_locations)
+    attempts = 0
+    while any(np.allclose(location, occ_loc) for occ_loc in task_locations):
         attempts += 1
         if attempts >= max_attempts:
             raise Exception(f"Could not find a unique task location after {max_attempts} attempts")
-        location = get_random_free_position(grid, all_occupied_locations)
+        location = get_random_free_position(grid, task_locations)
+    return location
+
+
+def get_unique_robot_location(robots, grid, occupied_locations=None, max_attempts=100):
+    """
+    Spawn rule: no two robot locations may overlap, but a robot may share a cell with a task.
+    Args:
+        robots: List of existing CapabilityProfile objects to check against.
+        grid: The grid representing the environment.
+        occupied_locations: Ignored for the overlap check (kept for backward-compat); only
+            other-robot locations are forbidden.
+        max_attempts: Maximum number of attempts before giving up.
+
+    Returns:
+        location: A unique (x, y, z) location tuple for the new robot.
+    """
+    robot_locations = {r.location for r in robots if getattr(r, "location", None) is not None}
+    location = get_random_free_position(grid, robot_locations)
+    attempts = 0
+    while any(np.allclose(location, occ_loc) for occ_loc in robot_locations):
+        attempts += 1
+        if attempts >= max_attempts:
+            raise Exception(f"Could not find a unique robot location after {max_attempts} attempts")
+        location = get_random_free_position(grid, robot_locations)
     return location
 
 def generate_random_robot_profile(robot_id: str, grid: List[List[int]], occupied_locations: set) -> CapabilityProfile:

--- a/hvbta/simulation/main_sim_no_CBS.py
+++ b/hvbta/simulation/main_sim_no_CBS.py
@@ -759,16 +759,25 @@ if __name__ == "__main__":
                                     voting_outputs = []
                                     assignment_infos = []
 
-                                    if robot_generation_strict:
-                                        robots = [G.generate_random_robot_profile_strict(f"R{idx+1}", grid, set()) for idx in range(num_robots)]
-                                        robot_profiles = [r.strict_profile_name for r in robots]
-                                    else:
-                                        robots = [G.generate_random_robot_profile(f"R{idx+1}", grid, set()) for idx in range(num_robots)]
-                                    if task_generation_strict:
-                                        tasks = [G.generate_random_task_description_strict(f"T{idx+1}", grid, set(), []) for idx in range(num_tasks)]
-                                        task_profiles = [t.strict_profile_name for t in tasks]
-                                    else:
-                                        tasks = [G.generate_random_task_description(f"T{idx+1}", grid, set(), []) for idx in range(num_tasks)]
+                                    # Spawn rule: robots may not overlap each other, tasks may not overlap
+                                    # each other, but a robot and a task may share a cell.
+                                    robot_locs = set()
+                                    robots = []
+                                    gen_robot = G.generate_random_robot_profile_strict if robot_generation_strict else G.generate_random_robot_profile
+                                    for idx in range(num_robots):
+                                        r = gen_robot(f"R{idx+1}", grid, robot_locs)
+                                        robots.append(r)
+                                        robot_locs.add(r.location)
+                                    robot_profiles = [r.strict_profile_name for r in robots] if robot_generation_strict else []
+
+                                    task_locs = set()
+                                    tasks = []
+                                    gen_task = G.generate_random_task_description_strict if task_generation_strict else G.generate_random_task_description
+                                    for idx in range(num_tasks):
+                                        t = gen_task(f"T{idx+1}", grid, task_locs, [])
+                                        tasks.append(t)
+                                        task_locs.add(t.location)
+                                    task_profiles = [t.strict_profile_name for t in tasks] if task_generation_strict else []
 
                                     pairwise_scorer = sm
                                     if getattr(sm, "_is_llm_batch", False):

--- a/hvbta/simulation/main_simulation.py
+++ b/hvbta/simulation/main_simulation.py
@@ -121,6 +121,75 @@ def run_cbs(robots, start_positions, goal_positions, map_dict):
     return float(np.mean(valid_lengths)) if valid_lengths else 0.0
 
 
+def reassign_robots_to_tasks_direct(
+        robots: List[CapabilityProfile],
+        tasks: List[TaskDescription],
+        bypass_fn,
+        unassigned_robots: List[str],
+        unassigned_tasks: List[str],
+        start_positions: dict,
+        goal_positions: dict,
+        llm_cache: dict = None):
+    """
+    Replan via a direct-assignment LLM (e.g. bypass_suitability_from_names_with_llm).
+    Mirrors the return shape of V.reassign_robots_to_tasks /
+    O.reassign_robots_to_tasks_with_method so the main loop can dispatch uniformly:
+        return_assignments, unassigned_robots, unassigned_tasks, score, length, per_agent_scores
+    The bypass operates only on the unassigned subset, so it never steals tasks from
+    busy robots. If a matrix cache is supplied, per-pair scores are read out of it for
+    the fairness metrics; otherwise per-pair scores default to 0.5 sentinel.
+    """
+    urobots = [r for r in robots if not r.assigned]
+    utasks = [t for t in tasks if not t.assigned]
+    if not urobots or not utasks:
+        return {}, unassigned_robots, unassigned_tasks, 0.0, 0.0, []
+
+    t0 = time.perf_counter_ns()
+    (sub_pairs, _unr_sub, _unt_sub), parse_failed = bypass_fn(urobots, utasks)
+    length = (time.perf_counter_ns() - t0) / 1000.0
+
+    if parse_failed:
+        print("[direct LLM replan] parse failed - leaving unassigned this tick")
+        return {}, unassigned_robots, unassigned_tasks, 0.0, length, []
+
+    cache_matrix = llm_cache.get("matrix") if llm_cache else None
+    r_to_idx = llm_cache.get("robot_id_to_idx") if llm_cache else None
+    t_to_idx = llm_cache.get("task_id_to_idx") if llm_cache else None
+
+    print(type(llm_cache["matrix"]))
+
+    return_assignments = {}
+    score = 0.0
+    for ri, ti in sub_pairs:
+        r = urobots[ri]
+        t = utasks[ti]
+        pair_score = 0.5
+        if (cache_matrix is not None and r_to_idx and t_to_idx
+                and r.robot_id in r_to_idx and t.task_id in t_to_idx):
+            pair_score = float(cache_matrix[r_to_idx[r.robot_id], t_to_idx[t.task_id]])
+
+        r.current_task = t
+        r.tasks_attempted += 1
+        r.assigned = True
+        t.assigned_robot = r
+        t.assigned = True
+        r.current_task_suitability = pair_score
+        t.current_suitability = pair_score
+        start_positions[r.robot_id] = r.location
+        goal_positions[r.robot_id] = t.location
+        return_assignments[r.robot_id] = t.task_id
+        score += pair_score
+
+    new_unassigned_robots = [r.robot_id for r in robots if not r.assigned]
+    new_unassigned_tasks = [t.task_id for t in tasks if not t.assigned]
+    per_agent_scores = [
+        float(r.current_task_suitability)
+        for r in robots
+        if r.assigned and r.current_task is not None and r.current_task_suitability is not None
+    ]
+    return return_assignments, new_unassigned_robots, new_unassigned_tasks, score, length, per_agent_scores
+
+
 def main_simulation(
         output: tuple,
         robots: List[CapabilityProfile],
@@ -315,7 +384,9 @@ def main_simulation(
                 # update it if not
                 if not cache_valid:
                     print(f"LLM cache miss - rebuilding matrix for {len(robots)} robots, {len(tasks)} tasks")
-                    suitability_matrix = suitability_method(robots, tasks)
+                    result = suitability_method(robots, tasks)
+                    # Unwrap (matrix, parse_failed) tuples so the cache stores a bare ndarray.
+                    suitability_matrix = result[0] if isinstance(result, tuple) else result
                     llm_cache["matrix"] = suitability_matrix
                     llm_cache["robot_id_to_idx"] = {r.robot_id: i for i, r in enumerate(robots)}
                     llm_cache["task_id_to_idx"] = {t.task_id: j for j, t in enumerate(tasks)}
@@ -343,6 +414,20 @@ def main_simulation(
                 _, unassigned_robots, unassigned_tasks, reassign_score, reassign_length, reassign_per_agent_scores = O.reassign_robots_to_tasks_with_method(
                     robots, tasks, num_candidates, voting_method, suitability_source,
                     unassigned_robots, unassigned_tasks, voting_method, start_positions, goal_positions, HYPOTENUSE,
+                )
+                if reassign_per_agent_scores:
+                    reassignment_jains_indices.append(calculate_jains_index(reassign_per_agent_scores))
+                    reassignment_fairness_metrics.append(compute_all_fairness_metrics(reassign_per_agent_scores))
+
+            # assign with direct LLM (bypass the matrix)
+            elif getattr(voting_method, "_is_llm_direct", False):
+                print("REASSIGNING WITH DIRECT LLM ASSIGNMENT")
+                total_reassignments += 1
+                _, unassigned_robots, unassigned_tasks, reassign_score, reassign_length, reassign_per_agent_scores = reassign_robots_to_tasks_direct(
+                    robots, tasks, voting_method,
+                    unassigned_robots, unassigned_tasks,
+                    start_positions, goal_positions,
+                    llm_cache=llm_cache,
                 )
                 if reassign_per_agent_scores:
                     reassignment_jains_indices.append(calculate_jains_index(reassign_per_agent_scores))
@@ -471,10 +556,10 @@ if __name__ == "__main__":
     direct_names = [func_name(f) for f in direct_methods]
     all_methods = voting_methods + optimization_methods + direct_methods
     suitability_methods = [
-        S.evaluate_suitability_balanced,
+        # S.evaluate_suitability_balanced,
         # S.evaluate_suitability_loose,
         # S.evaluate_suitability_strict,
-        # S.evaluate_suitability_from_names_with_llm,
+        S.evaluate_suitability_from_names_with_llm,
     ]
 
     small_maps = [
@@ -499,8 +584,8 @@ if __name__ == "__main__":
         # + random.sample(large_maps, 1)
     )
 
-    robot_sizes = [5]
-    task_sizes = [5]
+    robot_sizes = [2]
+    task_sizes = [2]
     Run_ID = 1
     num_repetitions = 1
     add_tasks = False
@@ -597,7 +682,11 @@ if __name__ == "__main__":
                                 task_profiles = [t.strict_profile_name for t in tasks] if task_generation_strict else []
 
                                 if getattr(sm, "_is_llm_batch", False):
-                                    suitability_matrix = sm(robots, tasks)
+                                    result = sm(robots, tasks)
+                                    # LLM scorers return (matrix, parse_failed); unwrap so the
+                                    # matrix is what flows through to llm_cache and downstream
+                                    # indexing in reassign_robots_to_tasks_direct.
+                                    suitability_matrix = result[0] if isinstance(result, tuple) else result
                                 else:
                                     suitability_matrix = S.calculate_suitability_matrix(robots, tasks, sm, HYPOTENUSE)
 

--- a/hvbta/simulation/main_simulation.py
+++ b/hvbta/simulation/main_simulation.py
@@ -4,60 +4,144 @@ import random
 import numpy as np
 import csv
 import os
-from typing import List
+import json
 import copy
+from typing import List
+
 from hvbta.pathfinding.Final_CBS import CBS, Environment
 from hvbta.simulation.timestep import simulate_time_step
 import hvbta.allocators.voting as V
+import hvbta.allocators.optimizers as O
 import hvbta.suitability as S
+import hvbta.generation as G
+from hvbta.metrics import (
+    calculate_jains_index,
+    calculate_threshold_metrics,
+    calculate_inequality_metrics,
+    calculate_robustness_metrics,
+)
 from hvbta.pathfinding.CBS import load_map, create_obstacle_list, build_cbs_agents
 from hvbta.allocators.misc_assignment import add_new_tasks, add_new_robots, remove_random_robots
-from hvbta.generation import generate_random_robot_profile_strict, generate_random_task_description_strict
 from hvbta.models import CapabilityProfile, TaskDescription
-import hvbta.allocators.optimizers as O
+
+
+def compute_all_fairness_metrics(scores):
+    """Flat tuple of fairness metrics in a consistent order for CSV output."""
+    jains = calculate_jains_index(scores)
+    threshold = calculate_threshold_metrics(scores)
+    inequality = calculate_inequality_metrics(scores)
+    robustness = calculate_robustness_metrics(scores)
+    return (
+        jains,
+        threshold["below_ge_frac"], threshold["below_good_frac"],
+        threshold["deficit_all_ge"], threshold["deficit_below_ge"],
+        threshold["deficit_all_good"], threshold["deficit_below_good"],
+        inequality["score_range"], inequality["min_max_ratio"],
+        inequality["gini"], inequality["cv"],
+        robustness["median"], robustness["mean"],
+        robustness["med_mean_gap"], robustness["iqr"],
+    )
+
+
+FAIRNESS_METRIC_NAMES = [
+    "Jains_Index",
+    "Below_GE_Frac", "Below_Good_Frac",
+    "Deficit_All_GE", "Deficit_Below_GE",
+    "Deficit_All_Good", "Deficit_Below_Good",
+    "Score_Range", "Min_Max_Ratio",
+    "Gini", "CV",
+    "Median", "Mean",
+    "Med_Mean_Gap", "IQR",
+]
+
+
+def func_name(f):
+    return getattr(f, "__name__", str(f))
+
 
 def suitability_all_zero(suitability_matrix):
     return all(value == 0 for row in suitability_matrix for value in row)
 
-def state_check(robots: List[CapabilityProfile], unassigned_robots: List[str], unassigned_tasks: List[str]):
-    """
-    Returns a state signature for deciding whether to re-plan.
-    Includes assigned robot goals plus unassigned robot/task pools.
-    """
-    active = []
-    goals = []
 
+def state_check(robots: List[CapabilityProfile], unassigned_robots: List[str], unassigned_tasks: List[str]):
+    """State signature for deciding whether to re-plan."""
+    active, goals = [], []
     for r in robots:
         if r.assigned and r.current_task:
             active.append(r.robot_id)
             goals.append((r.robot_id, tuple(r.current_task.location), r.current_task.task_id))
-    active_signature = tuple(sorted(active))
-    goals_signature = tuple(sorted(goals))
-    unassigned_robot_signature = tuple(sorted(unassigned_robots))
-    unassigned_task_signature = tuple(sorted(unassigned_tasks))
+    return (
+        tuple(sorted(active)),
+        tuple(sorted(goals)),
+        tuple(sorted(unassigned_robots)),
+        tuple(sorted(unassigned_tasks)),
+    )
 
-    return active_signature, goals_signature, unassigned_robot_signature, unassigned_task_signature
+
+def run_cbs(robots, start_positions, goal_positions, map_dict):
+    """
+    Plan all assigned-robot paths jointly with CBS. Writes resulting paths back
+    onto each robot's `current_path` and `remaining_distance`. Returns the average
+    path length over successful agents, or 0.0 if CBS fails / no agents.
+    """
+    if not start_positions or not goal_positions:
+        return 0.0
+
+    agents = build_cbs_agents(robots, start_positions, goal_positions)
+    if not agents:
+        return 0.0
+
+    # duplicate-start guard - CBS rejects this anyway, but fail fast and informative
+    start_locations = [a['start'] for a in agents]
+    if len(start_locations) != len(set(start_locations)):
+        print("ERROR: Duplicate start locations in agent list. Skipping CBS.")
+        return 0.0
+
+    env = Environment(
+        dimension=map_dict['dimension'],
+        agents=agents,
+        obstacles=map_dict['obstacles'],
+    )
+    res = CBS(env).search()
+    if not res:
+        print("CBS failed to find a plan under current constraints.")
+        return 0.0
+
+    solution, _nodes_expanded, _conflicts = res
+    id_to_index = {r.robot_id: idx for idx, r in enumerate(robots)}
+    valid_lengths = []
+    for robot_id, schedule in solution.items():
+        if robot_id not in id_to_index:
+            continue
+        r = robots[id_to_index[robot_id]]
+        r.current_path = [(p['x'], p['y']) for p in schedule]
+        r.remaining_distance = max(0, len(schedule) - 1)
+        if len(schedule) > 1:
+            valid_lengths.append(len(schedule) - 1)
+    return float(np.mean(valid_lengths)) if valid_lengths else 0.0
+
 
 def main_simulation(
-        output: tuple[list[tuple[int, int]],list[int],list[int]], 
-        robots: List[CapabilityProfile], tasks: List[TaskDescription], 
-        num_candidates: int, 
-        voting_method: callable, 
-        grid: List[List[int]], 
-        map_dict: dict, 
-        suitability_method: callable, 
-        suitability_matrix: np.ndarray, 
-        max_time_steps: int, 
-        add_tasks: bool, 
-        add_robots: bool, 
-        remove_robots: bool, 
-        tasks_to_add: int = 1, 
-        robots_to_add: int = 1, 
+        output: tuple,
+        robots: List[CapabilityProfile],
+        tasks: List[TaskDescription],
+        num_candidates: int,
+        voting_method: callable,
+        grid: List[List[int]],
+        map_dict: dict,
+        suitability_method: callable,
+        suitability_matrix: np.ndarray,
+        max_time_steps: int,
+        add_tasks: bool,
+        add_robots: bool,
+        remove_robots: bool,
+        tasks_to_add: int = 1,
+        robots_to_add: int = 1,
         robots_to_remove: int = 1,
         robot_generation_strict: bool = True,
-        task_generation_strict: bool = True):
+        task_generation_strict: bool = True,
+        initial_jains_index: float = 0.0):
     print(f"SUITABILITY METHOD: {suitability_method}")
-    # print(f"DEBUG STATEMENT 1")
 
     voting_methods = {
         V.rank_assignments_borda: "Borda Count",
@@ -65,214 +149,129 @@ def main_simulation(
         V.rank_assignments_majority_judgment: "Majority Judgment",
         V.rank_assignments_cumulative_voting: "Cumulative Voting",
         V.rank_assignments_condorcet_method: "Condorcet Method",
-        V.rank_assignments_range: "Range Voting"
+        V.rank_assignments_range: "Range Voting",
     }
-    if voting_method in voting_methods:
-        voting_method_name = voting_methods.get(voting_method, "Unknown Method")
     optimization_methods = {
         O.cbba_task_allocation: "CBBA",
         O.ssia_task_allocation: "SSIA",
         O.ilp_task_allocation: "ILP",
-        O.jv_task_allocation: "JV"
+        O.jv_task_allocation: "JV",
     }
-    if voting_method in optimization_methods:
-        optimization_method_name = optimization_methods.get(voting_method, "Unknown Method")
+    voting_method_name = voting_methods.get(voting_method, "Unknown Method")
+    optimization_method_name = optimization_methods.get(voting_method, "Unknown Method")
 
-    initial_positions = set()
-    robot_max_id = len(robots)+1
-    task_max_id = len(tasks)+1
+    HYPOTENUSE = (len(grid) ** 2 + len(grid[0]) ** 2) ** 0.5
     total_reward = 0.0
     total_success = 0.0
     total_tasks = len(tasks)
     total_reassignment_time = 0.0
     total_reassignment_score = 0.0
     total_reassignments = 0
+    total_time_steps = max_time_steps
+    reassignment_jains_indices = []
+    reassignment_fairness_metrics = []
+    reassign_score = 0.0
+    reassign_length = 0.0
 
-    # print(f"DEBUG STATEMENT 2")
+    # LLM suitability cache - reuse matrix unless NEW entities are added
+    llm_cache = {
+        "matrix": suitability_matrix if getattr(suitability_method, "_is_llm_batch", False) else None,
+        "robot_id_to_idx": {r.robot_id: i for i, r in enumerate(robots)} if getattr(suitability_method, "_is_llm_batch", False) else None,
+        "task_id_to_idx": {t.task_id: j for j, t in enumerate(tasks)} if getattr(suitability_method, "_is_llm_batch", False) else None,
+    }
 
-    for r in robots:
-        # add the robot's initial position to the occupied positions set
-        initial_positions.add(r.location)
+    occupied_positions = set(r.location for r in robots)
 
-    occupied_positions = set(initial_positions) # use the occcupied positions as the current positions for CBS, this is just as a occupation check, not a start position
-
+    # apply initial assignment
     assigned_pairs = output[0]
     for robot_idx, task_idx in assigned_pairs:
         r = robots[robot_idx]
         t = tasks[task_idx]
-
         r.current_task = t
         r.assigned = True
         r.tasks_attempted = 1
-
         t.assigned_robot = r
         t.assigned = True
 
-
-    assigned_robots = {r.robot_id: r.current_task.task_id for r in
-                       robots if r.assigned and r.current_task is not None}
     unassigned_tasks = [t.task_id for t in tasks if not t.assigned]
     unassigned_robots = [r.robot_id for r in robots if not r.assigned]
+    start_positions = {r.robot_id: r.location for r in robots if r.assigned and r.current_task}
+    goal_positions = {r.robot_id: r.current_task.location for r in robots if r.assigned and r.current_task}
 
-    start_positions = {
-        r.robot_id: r.location
-        for r in robots
-        if r.assigned and r.current_task is not None
-    }
-    goal_positions = {
-        r.robot_id: r.current_task.location
-        for r in robots
-        if r.assigned and r.current_task is not None
-    }
+    avg_path_length = run_cbs(robots, start_positions, goal_positions, map_dict)
 
-    print(f"ROBOTS: {[rob.robot_id for rob in robots]}")
-    print(f"TASKS: {[tas.task_id for tas in tasks]}")
-    print(f"ASSIGNED PAIRS: {assigned_pairs}")
-    print(f"ASSIGNED ROBOTS: {assigned_robots}")
-    print(f"UNASSIGNED ROBOTS: {unassigned_robots}")
-    print(f"UNASSIGNED TASKS: {unassigned_tasks}")
-
-    # print(f"DEBUG STATEMENT 3")
-
-    agents = build_cbs_agents(robots, start_positions, goal_positions)
-
-    print(f"AGENTS LIST: {agents}")
-
-    # Create the input data dictionary for CBS, this will be passed to the CBS planner
-    input_data = {
-        'map' : {
-            'dimension': map_dict['dimension'],
-            'obstacles': map_dict['obstacles']
-        },
-        'agents': agents,
-    }
-
-    # print(f"DEBUG STATEMENT 4")
-
-    env = Environment(
-        dimension=map_dict['dimension'],
-        agents=input_data['agents'],
-        obstacles=map_dict['obstacles'],
-    )
-
-    print(f"DEBUG STATEMENT BEFORE TIMESTEPS - ENVIRONMENT CREATED - AGENTS BUILT: {agents}")
-    planner = CBS(env)
-    res = planner.search()
-
-    # print(f"SOLUTION: {solution}")
-
-    if not res:
-        print("CBS failed to find a plan under current constraints.")
-        # could possibly fall back on the simple method here if we get a lot of issues
-    else:
-        solution, nodes_expanded, conflicts = res
-        print(f"SOLUTION: {solution}")
-
-        print(f"DEBUG STATEMENT - BEFORE TIMESTESP CBS COMPLETE - NODES EXPANDED: {nodes_expanded}, CONFLICTS: {conflicts}")
-
-        # Iterate through the agents and their schedules
-        id_to_index = {r.robot_id: idx for idx, r in enumerate(robots)}
-        for robot_id, schedule in solution.items():
-            ridx = id_to_index[robot_id]
-            robots[ridx].current_path = [(p['x'], p['y']) for p in schedule]
-            robots[ridx].remaining_distance = max(0, len(schedule) - 1)
-            print(f"Robot {robot_id} path: {robots[ridx].current_path}")
-
-    # Keep track of previous state to not run CBS when there are no changes
+    # create the initial state
     previous_active, previous_goals, previous_unassigned_robots, previous_unassigned_tasks = state_check(robots, unassigned_robots, unassigned_tasks)
-    current_active, current_goals, current_unassigned_robots, current_unassigned_tasks = state_check(robots, unassigned_robots, unassigned_tasks)
- 
-    # End the simulation if nothing changes for 3 timesteps and CBS stalling (hopefully the tasks are done and the robots arent moving)
-    time_steps_unchanged = 0
-
-    events = {
-        "new_tasks": 0,
-        "new_robots": 0,
-        "completed_tasks": 0,
-    }
-    idle_steps = {r.robot_id: 0 for r in robots} # track idleness of free robots
+    events = {"new_tasks": 0, "new_robots": 0, "completed_tasks": 0}
+    idle_steps = {r.robot_id: 0 for r in robots}
+    robot_max_id = len(robots) + 1
+    task_max_id = len(tasks) + 1
 
     for time_step in range(max_time_steps):
-        # print(f"DEBUG STATEMENT 7 - TIME STEP {time_step+1}")
-        # print(f"\n--- Time Step {time_step + 1} ---")
-        # print(f"OCCUPIED POSITIONS: {occupied_positions}")
-        print(f"AMOUNT OF ASSIGNED ROBOTS: {len([rob.current_task for rob in robots])}")
-        print(f"ASSIGNED ROBOTS: {[rob.assigned for rob in robots].count(True)}")
-        print(f"START POSITIONS: {start_positions}")
-        print(f"GOAL POSITIONS: {goal_positions}")
-        print(f"UNASSIGNED ROBOTS: {unassigned_robots}")
-        print(f"UNASSIGNED TASKS: {unassigned_tasks}")
-        # print(f"ALL ROBOTS: {len(robots)}")
-        # print(f"ALL TASKS: {len(tasks)}")
-        print(f"LIST OF ALL ROBOTS: {[rob.robot_id for rob in robots]}")
-        print(f"LIST OF ALL TASKS: {[tas.task_id for tas in tasks]}")
-
-        # before each time step, refresh the unassigned robots and tasks lists
+        # update unnasigned robots and tasks
         unassigned_robots = [r.robot_id for r in robots if not r.assigned]
         unassigned_tasks = [t.task_id for t in tasks if not t.assigned]
 
-        # Simulate time step
-        completed_this_step, unassigned_count, total_reward, total_success = simulate_time_step(
+        # simulate timestep
+        completed_this_step, _unassigned_count, total_reward, total_success = simulate_time_step(
             robots, tasks, unassigned_robots, unassigned_tasks,
-            suitability_method, occupied_positions, start_positions, 
-            goal_positions, 1.0, total_reward, total_success
+            suitability_method, occupied_positions, start_positions,
+            goal_positions, 1.0, total_reward, total_success,
         )
 
-        # print(f"DEBUG STATEMENT 8")
-
+        # check if no tasks are left
         if len(tasks) == 0:
-            print(f"All tasks completed in {time_step} time steps!")
+            print(f"All tasks completed in {time_step + 1} time steps!")
+            total_time_steps = time_step + 1
             break
-        events["completed_tasks"] += completed_this_step # track number of tasks completed
+
+        # update events with any completed tasks this timestep
+        events["completed_tasks"] += completed_this_step
+        # set the replan_cbs flag
         should_replan_cbs = completed_this_step > 0
 
-        # Periodically add new tasks and robots
-        if add_tasks and time_step + 1 <= 2 and random.random() < 0.5: # add tasks only in the first 2 time steps, and randomly
+        # add tasks
+        if add_tasks and time_step + 1 <= 2 and random.random() < 0.5:
             print(f"ADDING NEW TASKS AT TIME STEP {time_step + 1}")
-            num_of_tasks_added = random.randint(0, tasks_to_add)
+            n = random.randint(0, tasks_to_add)
             task_max_id, total_tasks = add_new_tasks(
-                tasks, unassigned_tasks, task_max_id, 
-                num_of_tasks_added, total_tasks, grid, 
-                occupied_positions, task_generation_strict
+                tasks, unassigned_tasks, task_max_id, n, total_tasks,
+                grid, occupied_positions, task_generation_strict,
             )
-            events["new_tasks"] += num_of_tasks_added # track number of tasks added
+            events["new_tasks"] += n
 
-        # print(f"DEBUG STATEMENT 9")
-
-        if add_robots and time_step + 1 <= 4 and random.random() < 0.5: # add robots only in the first 4 time steps, and randomly
+        # add robots
+        if add_robots and time_step + 1 <= 4 and random.random() < 0.5:
             print(f"ADDING NEW ROBOTS AT TIME STEP {time_step + 1}")
-            num_of_robots_added = random.randint(0, robots_to_add)
+            n = random.randint(0, robots_to_add)
             robot_max_id = add_new_robots(
-                robots, unassigned_robots, robot_max_id, 
-                num_of_robots_added, grid, occupied_positions, 
-                robot_generation_strict
+                robots, unassigned_robots, robot_max_id, n,
+                grid, occupied_positions, robot_generation_strict,
             )
-            events["new_robots"] += num_of_robots_added # track number of robots added
+            events["new_robots"] += n
             for r in robots:
-                if r.robot_id not in idle_steps:
-                    idle_steps[r.robot_id] = 0
+                idle_steps.setdefault(r.robot_id, 0)
 
-        # print(f"DEBUG STATEMENT 10")
-
-        # Periodically remove robots
-        if remove_robots and time_step + 1 <= 4 and random.random() < 0.5: # remove robots only in the first 4 time steps, and randomly
-            if len(robots) > 1: # Ensure at least one robot remains in the simulation
+        # remove robots
+        if remove_robots and time_step + 1 <= 4 and random.random() < 0.5:
+            if len(robots) > 1:
                 print(f"REMOVING RANDOM ROBOTS AT TIME STEP {time_step + 1}")
-                # Keeps track of which robots were removed so their idle state can be cleaned up
-                removed_robots = remove_random_robots(robots, tasks, unassigned_robots, unassigned_tasks, random.randint(0, robots_to_remove), occupied_positions, start_positions, goal_positions)
-                # Remove stale idle_steps entries for robots that are no longer in the simulation
-                for removed_robot in removed_robots: 
-                    idle_steps.pop(removed_robot.robot_id, None) 
-        # print(f"DEBUG STATEMENT 11")
+                removed = remove_random_robots(
+                    robots, tasks, unassigned_robots, unassigned_tasks,
+                    random.randint(0, robots_to_remove),
+                    occupied_positions, start_positions, goal_positions,
+                )
+                for removed_robot in removed:
+                    idle_steps.pop(removed_robot.robot_id, None)
 
+        # increment or reset idle steps for idle robots
         for r in robots:
             if not r.assigned:
-                idle_steps[r.robot_id] = idle_steps.get(r.robot_id, 0) + 1 # update idle steps of unassigned robots
+                idle_steps[r.robot_id] = idle_steps.get(r.robot_id, 0) + 1
             else:
                 idle_steps[r.robot_id] = 0
-        # stalling_robot = any(value >= 5 for value in idle_steps.values()) # if any robot has been idle for 5 or more steps, consider it stalling
-        
-        # Update start and goal positions before cbs
+
+        # refresh start/goal
         for robot in robots:
             if robot.assigned and robot.current_task:
                 start_positions[robot.robot_id] = robot.location
@@ -281,20 +280,15 @@ def main_simulation(
                 start_positions.pop(robot.robot_id, None)
                 goal_positions.pop(robot.robot_id, None)
 
-        # update planning signatures
+        # update state
         current_active, current_goals, current_unassigned_robots, current_unassigned_tasks = state_check(robots, unassigned_robots, unassigned_tasks)
 
-        # print(f"DEBUG STATEMENT 12")
-
-        # Update assigned robots
-        assigned_robots = {r.robot_id: r.current_task.task_id for r in robots if r.assigned and r.current_task}
-
-        # decide to reassign and replan
+        # check if there are any new events
         should_replan = False
-        # Allow replanning when either side changes, including dynamic task or robot arrivals
-        if unassigned_robots or unassigned_tasks or events["new_tasks"] or events["new_robots"]:
+        if unassigned_robots and unassigned_tasks:
             if events["new_tasks"] or events["new_robots"] or events["completed_tasks"]:
                 should_replan = True
+            # check if there is a state change
             elif (
                 current_active != previous_active
                 or current_goals != previous_goals
@@ -302,319 +296,370 @@ def main_simulation(
                 or current_unassigned_tasks != previous_unassigned_tasks
             ):
                 should_replan = True
-            # elif stalling_robot:
-            #     should_replan = True
-
         if should_replan:
             should_replan_cbs = True
 
-        # Reassign unassigned robots to unassigned tasks
-        if should_replan and start_positions and goal_positions:
-            print("State change, re-run CBS...")
-            # NOTE: here we need to reassign tasks based on the method used, voting vs optimizer
+        if should_replan:
+            # determine what to pass to the reassignment functions
+            if getattr(suitability_method, "_is_llm_batch", False):
+                current_robot_ids = {r.robot_id for r in robots}
+                current_task_ids = {t.task_id for t in tasks}
+                # check the LLM cache is valid
+                cache_valid = (
+                    llm_cache["matrix"] is not None
+                    and llm_cache["robot_id_to_idx"] is not None
+                    and llm_cache["task_id_to_idx"] is not None
+                    and current_robot_ids.issubset(llm_cache["robot_id_to_idx"].keys())
+                    and current_task_ids.issubset(llm_cache["task_id_to_idx"].keys())
+                )
+                # update it if not
+                if not cache_valid:
+                    print(f"LLM cache miss - rebuilding matrix for {len(robots)} robots, {len(tasks)} tasks")
+                    suitability_matrix = suitability_method(robots, tasks)
+                    llm_cache["matrix"] = suitability_matrix
+                    llm_cache["robot_id_to_idx"] = {r.robot_id: i for i, r in enumerate(robots)}
+                    llm_cache["task_id_to_idx"] = {t.task_id: j for j, t in enumerate(tasks)}
+                # use the updated cache as suitability source if LLM is suitibility method
+                suitability_source = (llm_cache["matrix"], llm_cache["robot_id_to_idx"], llm_cache["task_id_to_idx"])
+            else:
+                suitability_source = suitability_method
+
+            # assign with voting
             if voting_method in voting_methods:
                 print(f"REASSIGNING WITH VOTING METHOD: {voting_method_name}")
                 total_reassignments += 1
-                _, unassigned_robots, unassigned_tasks, reassign_score, reassign_length = V.reassign_robots_to_tasks(
-                    robots, tasks, num_candidates, voting_method, suitability_method,
-                    unassigned_robots, unassigned_tasks, start_positions, goal_positions
+                _, unassigned_robots, unassigned_tasks, reassign_score, reassign_length, reassign_per_agent_scores = V.reassign_robots_to_tasks(
+                    robots, tasks, num_candidates, voting_method, suitability_source,
+                    unassigned_robots, unassigned_tasks, start_positions, goal_positions, HYPOTENUSE,
                 )
+                if reassign_per_agent_scores:
+                    reassignment_jains_indices.append(calculate_jains_index(reassign_per_agent_scores))
+                    reassignment_fairness_metrics.append(compute_all_fairness_metrics(reassign_per_agent_scores))
+            
+            # assign with optimization
             elif voting_method in optimization_methods:
                 print(f"REASSIGNING WITH OPTIMIZATION METHOD: {optimization_method_name}")
                 total_reassignments += 1
-                _, unassigned_robots, unassigned_tasks, reassign_score, reassign_length = O.reassign_robots_to_tasks_with_method(
-                    robots, tasks, num_candidates, voting_method, suitability_method,
-                    unassigned_robots, unassigned_tasks, voting_method, start_positions, goal_positions
+                _, unassigned_robots, unassigned_tasks, reassign_score, reassign_length, reassign_per_agent_scores = O.reassign_robots_to_tasks_with_method(
+                    robots, tasks, num_candidates, voting_method, suitability_source,
+                    unassigned_robots, unassigned_tasks, voting_method, start_positions, goal_positions, HYPOTENUSE,
                 )
-            total_reassignment_time  += reassign_length
+                if reassign_per_agent_scores:
+                    reassignment_jains_indices.append(calculate_jains_index(reassign_per_agent_scores))
+                    reassignment_fairness_metrics.append(compute_all_fairness_metrics(reassign_per_agent_scores))
+            total_reassignment_time += reassign_length
             total_reassignment_score += reassign_score
 
-            # print(f"DEBUG STATEMENT 13")
-
-            # rebuild starts/goals after potential changes from reassignment
+            # update location dicts
             for robot in robots:
                 if robot.assigned and robot.current_task:
                     start_positions[robot.robot_id] = tuple(robot.location)
-                    goal_positions[robot.robot_id]  = tuple(robot.current_task.location)
+                    goal_positions[robot.robot_id] = tuple(robot.current_task.location)
                 else:
                     start_positions.pop(robot.robot_id, None)
                     goal_positions.pop(robot.robot_id, None)
-            print("***************************AFTER REASSIGNMENT***************************")
-            print(f"AMOUNT OF ASSIGNED ROBOTS: {len([rob.current_task for rob in robots])}")
-            print(f"ASSIGNED ROBOTS: {[rob.assigned for rob in robots].count(True)}")
-            print(f"START POSITIONS: {start_positions}")
-            print(f"GOAL POSITONS: {goal_positions}")
-            print(f"UNASSIGNED ROBOTS: {unassigned_robots}")
-            print(f"UNASSIGNED TASKS: {unassigned_tasks}")
-            print(f"LIST OF ALL ROBOTS: {[rob.robot_id for rob in robots]}")
-            print(f"LIST OF ALL TASKS: {[tas.task_id for tas in tasks]}")
-        
+
+        # rerun cbs if needed, update state, and clear events
         if should_replan_cbs and start_positions and goal_positions:
-            agents = build_cbs_agents(robots, start_positions, goal_positions)
+            avg_path_length = run_cbs(robots, start_positions, goal_positions, map_dict) or avg_path_length
+            previous_active, previous_goals, previous_unassigned_robots, previous_unassigned_tasks = state_check(robots, unassigned_robots, unassigned_tasks)
+            events = {k: 0 for k in events}
 
-            print(f"DEBUG STATEMENT - ENVIRONMENT CREATED - AGENTS BUILT: {agents}")
+    overall_success_rate = total_success / total_tasks if total_tasks else 0.0
+    avg_reassignment_score = (total_reassignment_score / total_reassignments) if total_reassignments > 0 else 0.0
+    avg_reassignment_jains_index = (sum(reassignment_jains_indices) / len(reassignment_jains_indices)) if reassignment_jains_indices else 0.0
 
-            # duplicate-start validation
-            start_locations = [a['start'] for a in agents]
-            if len(start_locations) != len(set(start_locations)):
-                print("ERROR: Duplicate start locations found in agent list. Aborting CBS.")
-                solution = None
-            else:
-                env = Environment(dimension=map_dict['dimension'], agents=agents, obstacles=map_dict['obstacles'])
-                planner = CBS(env)
-                res = planner.search()
-                # print(f"CBS COMPLETE. New solution: {solution}")
+    if reassignment_fairness_metrics:
+        num_metrics = len(FAIRNESS_METRIC_NAMES)
+        avg_reassign_metrics = tuple(
+            sum(m[i] for m in reassignment_fairness_metrics) / len(reassignment_fairness_metrics)
+            for i in range(num_metrics)
+        )
+    else:
+        avg_reassign_metrics = tuple(0.0 for _ in FAIRNESS_METRIC_NAMES)
 
-                print(f"DEBUG STATEMENT - CBS COMPLETE - NODES EXPANDED: {nodes_expanded}, CONFLICTS: {conflicts}")
+    print(f"Voting: Total reward: {total_reward}, Overall success rate: {overall_success_rate:.2%}, "
+          f"Tasks completed: {total_success}, Reassignment Time: {total_reassignment_time}, "
+          f"Reassignment Score: {total_reassignment_score}, total reassignments: {total_reassignments}, "
+          f"total tasks: {total_tasks}, Total robots: {len(robots)}")
 
-                if res:
-                    solution, nodes_expanded, conflicts = res
-                    print(f"CBS COMPLETE. New solution: {solution}")
-                    id_to_index = {r.robot_id: idx for idx, r in enumerate(robots)}
-                    for robot_id, schedule in solution.items():
-                        ridx = id_to_index[robot_id]
-                        r = robots[ridx]
-                        r.current_path = [(p['x'], p['y']) for p in schedule]
-                        r.remaining_distance = max(0, len(schedule) - 1)
+    return (
+        total_reward, overall_success_rate, total_success,
+        total_reassignment_time, total_reassignment_score, total_reassignments,
+        min(total_time_steps, max_time_steps), avg_reassignment_score, avg_path_length,
+        initial_jains_index, avg_reassignment_jains_index,
+    ) + avg_reassign_metrics[1:]  # skip first (Jains) - already exposed above
 
-                    previous_active, previous_goals, previous_unassigned_robots, previous_unassigned_tasks = state_check(robots, unassigned_robots, unassigned_tasks)  # update to the post-replan state
-                    events = {k: 0 for k in events}  # reset counters we just consumed
-
-                    # print(f"DEBUG STATEMENT 16")
-                else:
-                    print("CBS failed to find a plan under current constraints.")
-                    # could possibly fall back on the simple method here if we get a lot of issues
-                    # but for now, we will just skip CBS and continue with the simulation
-                    print("Skipping CBS...")
-                    events = {k: 0 for k in events}  # reset counters even when CBS fails
-                    time_steps_unchanged += 1
-                    # print(f"DEBUG STATEMENT 17 - TIME STEPS UNCHANGED {time_steps_unchanged}")
-                    if time_steps_unchanged >= 3:
-                        print("No state change for 3 time steps, ending simulation.")
-                        break
-        else:
-            print("No state change, skip CBS...")
-            print(f"ALL ROBOTS: {len(robots)}")
-            print(f"ALL TASKS: {len(tasks)}")
-            print(f"LIST OF ALL ROBOTS: {[rob.robot_id for rob in robots]}")
-            print(f"LIST OF ALL TASKS: {[tas.task_id for tas in tasks]}")
-            # print(f"DEBUG STATEMENT 18")
-
-    # print(f"DEBUG STATEMENT 19")
-    overall_success_rate = total_success / total_tasks
-    print(f"Voting: Total reward: {total_reward}, Overall success rate: {overall_success_rate:.2%}, Tasks completed: {total_success}, Reassignment Time: {total_reassignment_time}, Reassignment Score: {total_reassignment_score}, total reassignments: {total_reassignments}")
-    return (total_reward, overall_success_rate, total_success, total_reassignment_time, total_reassignment_score, total_reassignments)
-#     for robot in robots:
-#         print(f"Robot {robot.robot_id} attempted {robot.tasks_attempted} tasks and successfully completed {robot.tasks_successful} of them.")
 
 def benchmark_simulation(
-        output: tuple[list[tuple[int, int]],list[int],list[int]], 
-        robots: List[CapabilityProfile], tasks: List[TaskDescription], 
-        num_candidates: int, 
-        voting_method: callable, 
-        grid: List[List[int]], 
-        map_dict: dict, 
-        suitability_method: callable, 
-        suitability_matrix: np.ndarray, 
-        max_time_steps: int, 
-        add_tasks: bool, 
-        add_robots: bool, 
-        remove_robots: bool, 
-        tasks_to_add: int = 1, 
-        robots_to_add: int = 1, 
+        output: tuple,
+        robots: List[CapabilityProfile],
+        tasks: List[TaskDescription],
+        num_candidates: int,
+        voting_method: callable,
+        grid: List[List[int]],
+        map_dict: dict,
+        suitability_method: callable,
+        suitability_matrix: np.ndarray,
+        max_time_steps: int,
+        add_tasks: bool,
+        add_robots: bool,
+        remove_robots: bool,
+        tasks_to_add: int = 1,
+        robots_to_add: int = 1,
         robots_to_remove: int = 1,
         robot_generation_strict: bool = True,
-        task_generation_strict: bool = True):
-    start_time = time.time()
+        task_generation_strict: bool = True,
+        initial_jains_index: float = 0.0):
+    start_time = time.perf_counter_ns()
     output_tuple = main_simulation(
-        output, robots, tasks, num_candidates, voting_method, 
-        grid, map_dict, suitability_method, suitability_matrix, 
-        max_time_steps, add_tasks, add_robots, remove_robots, 
+        output, robots, tasks, num_candidates, voting_method,
+        grid, map_dict, suitability_method, suitability_matrix,
+        max_time_steps, add_tasks, add_robots, remove_robots,
         tasks_to_add, robots_to_add, robots_to_remove,
-        robot_generation_strict, task_generation_strict)
-    end_time = time.time()
-    execution_time = end_time - start_time
-
+        robot_generation_strict, task_generation_strict,
+        initial_jains_index=initial_jains_index,
+    )
+    execution_time = time.perf_counter_ns() - start_time
     cpu_usage = psutil.cpu_percent()
     memory_usage = psutil.virtual_memory().used
 
-    print(f"Simulation completed in {execution_time:.2f} seconds.")
+    print(f"Simulation completed in {execution_time:.5f} nanoseconds.")
     print(f"CPU Usage: {cpu_usage}%")
     print(f"Memory Usage: {memory_usage / (1024 * 1024)} MB")
 
     return output_tuple + (execution_time, cpu_usage, memory_usage)
 
+
+def _record_assignment(assignment_infos, run_id, method_name, sm_name, num_robots,
+                       num_tasks, nc, score, length, per_agent_scores):
+    """Compute initial fairness metrics, derived score fields, and append a row."""
+    metrics = compute_all_fairness_metrics(per_agent_scores)
+    assigned_count = len(per_agent_scores) if per_agent_scores else 0
+    task_normalized = (score / assigned_count) if assigned_count > 0 else 0.0
+    score_density = (score / (num_robots * num_tasks)) if num_robots * num_tasks > 0 and score > 0 else 0.0
+    assignment_infos.append(
+        [run_id, method_name, sm_name, num_robots, num_tasks, nc, score,
+         task_normalized, score_density, length] + list(metrics)
+    )
+    return metrics[0]  # initial jains
+
+
 if __name__ == "__main__":
-        voting_methods = [
-            V.rank_assignments_borda, 
-            V.rank_assignments_approval, 
-            V.rank_assignments_majority_judgment, 
-            V.rank_assignments_cumulative_voting, 
-            V.rank_assignments_condorcet_method, 
-            V.rank_assignments_range
-            ]
-        voting_names = [
-            "rank_assignments_borda", 
-            "rank_assignments_approval", 
-            "rank_assignments_majority_judgment", 
-            "rank_assignments_cumulative_voting", 
-            "rank_assignments_condorcet_method", 
-            "rank_assignments_range"
-            ]
-        allocation_methods = [
-            O.cbba_task_allocation, 
-            O.ssia_task_allocation, 
-            O.ilp_task_allocation, 
-            O.jv_task_allocation
-            ]
-        allocation_names = [
-            "cbba_task_allocation", 
-            "ssia_task_allocation", 
-            "ilp_task_allocation", 
-            "jv_task_allocation"
-            ]
-        all_methods = [
-            V.rank_assignments_borda,
-            V.rank_assignments_approval,
-            V.rank_assignments_majority_judgment,
-            V.rank_assignments_cumulative_voting,
-            V.rank_assignments_condorcet_method,
-            V.rank_assignments_range,
-            O.cbba_task_allocation,
-            O.ssia_task_allocation,
-            O.ilp_task_allocation,
-            O.jv_task_allocation
-            ]
-        suitability_methods = [
-            S.evaluate_suitability_new, 
-            S.evaluate_suitability_loose, 
-            S.evaluate_suitability_strict
-            ]
-        max_time_steps = 100
-        robot_sizes = [8, 10, 15]
-        # candidate_sizes = [5, 10, 15]
-        num_repetitions = 1
-        add_tasks = False
-        add_robots = False
-        remove_robots = False
-        robot_generation_strict = True
-        task_generation_strict = True
-        map_file = r"test_small_open.map"
-        # dir_path = r"hvbta\io\results"
-        dir_path = os.path.join('hvbta', 'io', 'results')
-        grid = load_map(map_file) # 2D list of 0/1 representing the map
-        dims = (len(grid), len(grid[0])) # dimensions of the map grid
-        obstacles = create_obstacle_list(grid) # list of obstacle coordinates
-        map_dict = {
-            'dimension': dims,
-            'obstacles': obstacles
-        }
-        with open(os.path.join(dir_path, "simulation_results.csv"), mode="w", newline='') as file:
+    voting_methods = [
+        V.rank_assignments_borda,
+        V.rank_assignments_approval,
+        V.rank_assignments_majority_judgment,
+        V.rank_assignments_cumulative_voting,
+        V.rank_assignments_condorcet_method,
+        V.rank_assignments_range,
+    ]
+    voting_names = [func_name(f) for f in voting_methods]
+    optimization_methods = [
+        O.cbba_task_allocation,
+        O.ssia_task_allocation,
+        O.ilp_task_allocation,
+        O.jv_task_allocation,
+    ]
+    optimization_names = [func_name(f) for f in optimization_methods]
+    # Direct-assignment methods: the LLM returns (robot_id, task_id) pairs straight up,
+    # bypassing the suitability-matrix + voting/optimization stack. Slot here so it
+    # benchmarks alongside the others.
+    direct_methods = [
+        S.bypass_suitability_from_names_with_llm,
+    ]
+    direct_names = [func_name(f) for f in direct_methods]
+    all_methods = voting_methods + optimization_methods + direct_methods
+    suitability_methods = [
+        S.evaluate_suitability_balanced,
+        # S.evaluate_suitability_loose,
+        # S.evaluate_suitability_strict,
+        # S.evaluate_suitability_from_names_with_llm,
+    ]
+
+    small_maps = [
+        r"den201d.map", r"den202d.map", r"den404d.map", r"lak101d.map",
+        r"lak102d.map", r"lak105d.map", r"lak107d.map", r"lak108d.map",
+    ]
+    medium_maps = [
+        r"arena.map", r"den009d.map", r"den101d.map", r"den204d.map",
+        r"den207d.map", r"den403d.map", r"den405d.map", r"den407d.map",
+        r"den408d.map", r"hrt002d.map", r"isound1.map", r"lak103d.map",
+        r"lak104d.map",
+    ]
+    large_maps = [
+        r"den001d.map", r"den020d.map", r"den203d.map", r"den206d.map",
+        r"den308d.map", r"den312d.map", r"den900d.map", r"den901d.map",
+        r"den998d.map", r"hrt001d.map", r"lak106d.map", r"lak203d.map",
+        r"lak307d.map", r"ost002d.map",
+    ]
+    map_paths = (
+        random.sample(small_maps, 1)
+        # + random.sample(medium_maps, 1)
+        # + random.sample(large_maps, 1)
+    )
+
+    robot_sizes = [5]
+    task_sizes = [5]
+    Run_ID = 1
+    num_repetitions = 1
+    add_tasks = False
+    add_robots = False
+    remove_robots = False
+    robot_generation_strict = True
+    task_generation_strict = True
+    map_dir = r"MAPF_benchmark_maps"
+
+    dir_path = os.path.join('hvbta', 'io', 'results')
+    os.makedirs(dir_path, exist_ok=True)
+    full_paths = [os.path.join(map_dir, m) for m in map_paths]
+
+    for map_file in full_paths:
+        grid = load_map(map_file)
+        HYPOTENUSE = (len(grid) ** 2 + len(grid[0]) ** 2) ** 0.5
+        dims = (len(grid), len(grid[0]))
+        map_size = "Small" if dims[0] < 40 and dims[1] < 40 else "Medium" if dims[0] < 75 and dims[1] < 75 else "Large"
+        obstacles = create_obstacle_list(grid)
+        map_dict = {'dimension': dims, 'obstacles': obstacles}
+
+        results_path = os.path.join(dir_path, f"CBS_simulation_results_{os.path.basename(map_file)}.csv")
+        profiles_path = os.path.join(dir_path, f"CBS_profiles_{os.path.basename(map_file)}.csv")
+
+        with open(results_path, mode="w", newline='') as file, \
+             open(profiles_path, mode="w", newline='') as profile_file:
             writer = csv.writer(file)
+            profiles_w = csv.writer(profile_file)
+
             writer.writerow([
-                'Method', 'Suitability Method', 'Num Robots', 
-                'Num Tasks', 'Num Candidates', 'Total Score', 
-                'Task Normalized Score', 'Score Density', 'Length', 
-                'total_reward', 'overall_success_rate', 'total_success', 
-                'total_reassignment_time', 'total_reassignment_score', 
-                'total_reassignments', 'Execution Time', 'CPU Usage', 'Memory Usage'])
+                'Run ID', 'Method', 'Suitability Method', 'Num Robots',
+                'Num Tasks', 'Num Candidates', 'Total Score',
+                'Task Normalized Score', 'Score Density', 'Length',
+                'Init_Jains_Index', 'Init_Below_GE_Frac', 'Init_Below_Good_Frac',
+                'Init_Deficit_All_GE', 'Init_Deficit_Below_GE',
+                'Init_Deficit_All_Good', 'Init_Deficit_Below_Good',
+                'Init_Score_Range', 'Init_Min_Max_Ratio',
+                'Init_Gini', 'Init_CV',
+                'Init_Median', 'Init_Mean',
+                'Init_Med_Mean_Gap', 'Init_IQR',
+                'total_reward', 'overall_success_rate', 'total_success',
+                'total_reassignment_time', 'total_reassignment_score',
+                'total_reassignments', 'Total Time Steps', 'Average Reassignment Score',
+                'Average Path Length', 'Initial Jains Index (sim)', 'Avg Reassignment Jains Index',
+                'Avg_Reass_Below_GE_Frac', 'Avg_Reass_Below_Good_Frac',
+                'Avg_Reass_Deficit_All_GE', 'Avg_Reass_Deficit_Below_GE',
+                'Avg_Reass_Deficit_All_Good', 'Avg_Reass_Deficit_Below_Good',
+                'Avg_Reass_Score_Range', 'Avg_Reass_Min_Max_Ratio',
+                'Avg_Reass_Gini', 'Avg_Reass_CV',
+                'Avg_Reass_Median', 'Avg_Reass_Mean',
+                'Avg_Reass_Med_Mean_Gap', 'Avg_Reass_IQR',
+                'Execution Time', 'CPU Usage', 'Memory Usage', 'Map Size',
+            ])
+            profiles_w.writerow([
+                'Run_ID', 'Map', 'Num Robots', 'Num Tasks',
+                'Suitability Method', 'RobotProfiles', 'TaskProfiles',
+            ])
+
             for num_robots in robot_sizes:
                 print(f"\n\n\nSTARTING SIMULATION FOR {num_robots} ROBOTS")
-                task_sizes = [
-                    # int(num_robots * 0.5),
-                    int(num_robots * 0.75),
-                    num_robots,
-                    int(num_robots * 1.25),
-                    # int(num_robots * 1.5)
-                ]
                 for num_tasks in task_sizes:
                     print(f"\n\n\nSTARTING SIMULATION FOR {num_tasks} TASKS")
-                    candidate_sizes = [
-                        max(1, int(num_robots * 0.75)),
-                            max(1, int(num_tasks * 1)),
-                    ]
+                    candidate_sizes = [50]
+                    workload = max(1.0, num_tasks / num_robots)
+                    extender = 1.5 if workload > 10 else 1.2 if workload > 5 else 1.0
+                    max_time_steps = max(200, int(HYPOTENUSE * 1.5 * extender))
+
                     for nc in candidate_sizes:
-                        print(f"\n\n\nSTARTING SIMULATION FOR {nc} CANDIDATES")
                         for sm in suitability_methods:
-                            print(f"\n\n\nSTARTING SIMULATION FOR SUITABILITY METHOD: {sm}")
+                            sm_name = func_name(sm)
                             for rep in range(num_repetitions):
                                 print(f"\n\n\nSTARTING SIMULATION REPETITION {rep+1}/{num_repetitions}")
                                 voting_outputs = []
                                 assignment_infos = []
-                                robots = [generate_random_robot_profile_strict(f"R{idx+1}", grid, set()) for idx in range(num_robots)]
-                                tasks = [generate_random_task_description_strict(f"T{idx+1}", grid, set(), []) for idx in range(num_tasks)]
-                                suitability_matrix = S.calculate_suitability_matrix(robots, tasks, sm)
-                                # while suitability_all_zero(suitability_matrix): #change this to just random assignment when there is all zeros
-                                #     robots = [generate_random_robot_profile_strict(f"R{idx+1}", grid, set()) for idx in range(num_robots)]
-                                #     tasks = [generate_random_task_description_strict(f"T{idx+1}", grid, set(), []) for idx in range(num_tasks)]
-                                #     suitability_matrix = S.calculate_suitability_matrix(robots, tasks, sm)
-                                if suitability_all_zero(suitability_matrix):
-                                    for method_idx in range(len(voting_methods)):
-                                        print("All suitability scores are zero, randomly assigning tasks to robots.")
-                                        output, score, length = V.assign_tasks_randomly(robots, tasks, suitability_matrix, nc)
-                                        assigned_count = len(output[0]) if output and output[0] else 0
-                                        task_normalized_score = (score / assigned_count) if assigned_count > 0 else 0.0
-                                        score_density = (score / (num_robots * num_tasks)) if (num_robots * num_tasks) > 0 else 0.0
-                                        # writer.writerow([voting_names[method_idx], sm, num_robots, num_tasks, nc, score, task_normalized_score, score_density, length])
-                                        assignment_infos.append([voting_names[method_idx], sm, num_robots, num_tasks, nc, score, task_normalized_score, score_density, length])
-                                        voting_outputs.append(output)
-                                    cbba_output, cbba_score, cbba_length = O.assign_tasks_with_method_randomly(O.cbba_task_allocation, suitability_matrix, nc)
-                                    assigned_count = len(cbba_output[0]) if cbba_output and cbba_output[0] else 0 # nuber of pairs in the chosen assignment
-                                    task_normalized_score = (cbba_score / assigned_count) if assigned_count > 0 else 0.0
-                                    score_density = (cbba_score / (num_robots * num_tasks)) if (num_robots * num_tasks) > 0 else 0.0
-                                    assignment_infos.append(["cbba_task_allocation", sm, num_robots, num_tasks, nc, cbba_score, task_normalized_score, score_density, cbba_length])
-                                    ssia_output, ssia_score, ssia_length = O.assign_tasks_with_method_randomly(O.ssia_task_allocation, suitability_matrix, nc)
-                                    assigned_count = len(ssia_output[0]) if ssia_output and ssia_output[0] else 0
-                                    task_normalized_score = (ssia_score / assigned_count) if assigned_count > 0 else 0.0
-                                    score_density = (ssia_score / (num_robots * num_tasks)) if (num_robots * num_tasks) > 0 else 0.0
-                                    assignment_infos.append(["ssia_task_allocation", sm, num_robots, num_tasks, nc, ssia_score, task_normalized_score, score_density, ssia_length])
-                                    ilp_output, ilp_score, ilp_length = O.assign_tasks_with_method_randomly(O.ilp_task_allocation, suitability_matrix, nc)
-                                    assigned_count = len(ilp_output[0]) if ilp_output and ilp_output[0] else 0
-                                    task_normalized_score = (ilp_score / assigned_count) if assigned_count > 0 else 0.0
-                                    score_density = (ilp_score / (num_robots * num_tasks)) if (num_robots * num_tasks) > 0 else 0.0
-                                    assignment_infos.append(["ilp_task_allocation", sm, num_robots, num_tasks, nc, ilp_score, task_normalized_score, score_density, ilp_length])
-                                    jv_output, jv_score, jv_length = O.assign_tasks_with_method_randomly(O.jv_task_allocation, suitability_matrix, nc)
-                                    assigned_count = len(jv_output[0]) if jv_output and jv_output[0] else 0
-                                    task_normalized_score = (jv_score / assigned_count) if assigned_count > 0 else 0.0
-                                    score_density = (jv_score / (num_robots * num_tasks)) if (num_robots * num_tasks) > 0 else 0.0
-                                    assignment_infos.append(["jv_task_allocation", sm, num_robots, num_tasks, nc, jv_score, task_normalized_score, score_density, jv_length])
-                                    outputs = voting_outputs + [cbba_output, ssia_output, ilp_output, jv_output]
-                                    
+
+                                # Spawn rule: robots may not overlap each other, tasks may not overlap
+                                # each other, but a robot and a task may share a cell.
+                                robot_locs = set()
+                                robots = []
+                                gen_robot = G.generate_random_robot_profile_strict if robot_generation_strict else G.generate_random_robot_profile
+                                for idx in range(num_robots):
+                                    r = gen_robot(f"R{idx+1}", grid, robot_locs)
+                                    robots.append(r)
+                                    robot_locs.add(r.location)
+                                robot_profiles = [r.strict_profile_name for r in robots] if robot_generation_strict else []
+
+                                task_locs = set()
+                                tasks = []
+                                gen_task = G.generate_random_task_description_strict if task_generation_strict else G.generate_random_task_description
+                                for idx in range(num_tasks):
+                                    t = gen_task(f"T{idx+1}", grid, task_locs, [])
+                                    tasks.append(t)
+                                    task_locs.add(t.location)
+                                task_profiles = [t.strict_profile_name for t in tasks] if task_generation_strict else []
+
+                                if getattr(sm, "_is_llm_batch", False):
+                                    suitability_matrix = sm(robots, tasks)
                                 else:
-                                    for method_idx in range(len(voting_methods)):
-                                        output, score, length = V.assign_tasks_with_voting(robots, tasks, suitability_matrix, nc, voting_methods[method_idx])
-                                        assigned_count = len(output[0]) if output and output[0] else 0 # nuber of pairs in the chosen assignment
-                                        task_normalized_score = (score / assigned_count) if assigned_count > 0 else 0.0 # per assigned task normalized score
-                                        score_density = (score / (num_robots * num_tasks)) if (num_robots * num_tasks) > 0 else 0.0
-                                        assignment_infos.append([voting_names[method_idx], sm, num_robots, num_tasks, nc, score, task_normalized_score, score_density, length])
-                                        voting_outputs.append(output)
-                                    cbba_output, cbba_score, cbba_length = O.assign_tasks_with_method(O.cbba_task_allocation,suitability_matrix)
-                                    assigned_count = len(cbba_output[0]) if cbba_output and cbba_output[0] else 0 # nuber of pairs in the chosen assignment
-                                    task_normalized_score = (cbba_score / assigned_count) if assigned_count > 0 else 0.0
-                                    score_density = (cbba_score / (num_robots * num_tasks)) if (num_robots * num_tasks) > 0 else 0.0
-                                    assignment_infos.append(["cbba_task_allocation", sm, num_robots, num_tasks, nc, cbba_score, task_normalized_score, score_density, cbba_length])
-                                    ssia_output, ssia_score, ssia_length = O.assign_tasks_with_method(O.ssia_task_allocation,suitability_matrix)
-                                    assigned_count = len(ssia_output[0]) if ssia_output and ssia_output[0] else 0
-                                    task_normalized_score = (ssia_score / assigned_count) if assigned_count > 0 else 0.0
-                                    score_density = (ssia_score / (num_robots * num_tasks)) if (num_robots * num_tasks) > 0 else 0.0
-                                    assignment_infos.append(["ssia_task_allocation", sm, num_robots, num_tasks, nc, ssia_score, task_normalized_score, score_density, ssia_length])
-                                    ilp_output, ilp_score, ilp_length = O.assign_tasks_with_method(O.ilp_task_allocation,suitability_matrix)
-                                    assigned_count = len(ilp_output[0]) if ilp_output and ilp_output[0] else 0
-                                    task_normalized_score = (ilp_score / assigned_count) if assigned_count > 0 else 0.0
-                                    score_density = (ilp_score / (num_robots * num_tasks)) if (num_robots * num_tasks) > 0 else 0.0
-                                    assignment_infos.append(["ilp_task_allocation", sm, num_robots, num_tasks, nc, ilp_score, task_normalized_score, score_density, ilp_length])
-                                    jv_output, jv_score, jv_length = O.assign_tasks_with_method(O.jv_task_allocation,suitability_matrix)
-                                    assigned_count = len(jv_output[0]) if jv_output and jv_output[0] else 0
-                                    task_normalized_score = (jv_score / assigned_count) if assigned_count > 0 else 0.0
-                                    score_density = (jv_score / (num_robots * num_tasks)) if (num_robots * num_tasks) > 0 else 0.0
-                                    assignment_infos.append(["jv_task_allocation", sm, num_robots, num_tasks, nc, jv_score, task_normalized_score, score_density, jv_length])
-                                outputs = voting_outputs + [cbba_output, ssia_output, ilp_output, jv_output]
-                                for idx, (out, meth) in enumerate(zip(outputs, all_methods)):
-                                    print(f"\n\n\nRUNNING SIMULATION FOR METHOD: {meth}")
+                                    suitability_matrix = S.calculate_suitability_matrix(robots, tasks, sm, HYPOTENUSE)
+
+                                if robot_generation_strict and task_generation_strict:
+                                    profiles_w.writerow([
+                                        Run_ID, os.path.basename(map_file),
+                                        num_robots, num_tasks, sm_name,
+                                        json.dumps(robot_profiles), json.dumps(task_profiles),
+                                    ])
+
+                                # Direct LLM assignment is independent of the matrix; time it and
+                                # score its chosen pairs against the rule-based matrix for parity
+                                # with voting/optimization rows.
+                                direct_outputs = []
+                                for d_fn, d_name in zip(direct_methods, direct_names):
+                                    d_start = time.perf_counter_ns()
+                                    out, parse_failed = d_fn(robots, tasks)
+                                    d_length = (time.perf_counter_ns() - d_start) / 1000.0
+                                    if parse_failed:
+                                        print(f"[{d_name}] parse failed - empty assignment fallback")
+                                    pairs = out[0]
+                                    per_agent_direct = [float(suitability_matrix[r][t]) for (r, t) in pairs] if not isinstance(suitability_matrix, tuple) else [0.0] * len(pairs)
+                                    d_score = sum(per_agent_direct)
+                                    initial_jains = _record_assignment(assignment_infos, Run_ID, d_name, sm_name, num_robots, num_tasks, nc, d_score, d_length, per_agent_direct)
+                                    direct_outputs.append((out, initial_jains))
+
+                                if suitability_all_zero(suitability_matrix):
+                                    # voting - random fallback
+                                    for method_fn, method_name in zip(voting_methods, voting_names):
+                                        output, score, length, per_agent = V.assign_tasks_randomly(robots, tasks, suitability_matrix, nc)
+                                        initial_jains = _record_assignment(assignment_infos, Run_ID, method_name, sm_name, num_robots, num_tasks, nc, score, length, per_agent)
+                                        voting_outputs.append((output, initial_jains))
+                                    # optimization - random fallback
+                                    opt_outputs = []
+                                    for opt_fn, opt_name in zip(optimization_methods, optimization_names):
+                                        out, score, length, per_agent = O.assign_tasks_with_method_randomly(opt_fn, suitability_matrix, nc)
+                                        initial_jains = _record_assignment(assignment_infos, Run_ID, opt_name, sm_name, num_robots, num_tasks, nc, score, length, per_agent)
+                                        opt_outputs.append((out, initial_jains))
+                                    outputs = voting_outputs + opt_outputs + direct_outputs
+                                else:
+                                    # voting - normal
+                                    for method_fn, method_name in zip(voting_methods, voting_names):
+                                        output, score, length, per_agent = V.assign_tasks_with_voting(robots, tasks, suitability_matrix, nc, method_fn)
+                                        initial_jains = _record_assignment(assignment_infos, Run_ID, method_name, sm_name, num_robots, num_tasks, nc, score, length, per_agent)
+                                        voting_outputs.append((output, initial_jains))
+                                    # optimization - normal
+                                    opt_outputs = []
+                                    for opt_fn, opt_name in zip(optimization_methods, optimization_names):
+                                        out, score, length, per_agent = O.assign_tasks_with_method(opt_fn, suitability_matrix)
+                                        initial_jains = _record_assignment(assignment_infos, Run_ID, opt_name, sm_name, num_robots, num_tasks, nc, score, length, per_agent)
+                                        opt_outputs.append((out, initial_jains))
+                                    outputs = voting_outputs + opt_outputs + direct_outputs
+
+                                for idx, (out_tuple, meth) in enumerate(zip(outputs, all_methods)):
+                                    out, initial_jains = out_tuple
                                     output_tuple = benchmark_simulation(
-                                        out, copy.deepcopy(robots), copy.deepcopy(tasks), 
-                                        nc, meth, grid, map_dict, sm, suitability_matrix, 
-                                        max_time_steps, add_tasks, add_robots, remove_robots, 
-                                        10, 10, 10, robot_generation_strict, task_generation_strict)
-                                    row_prefix = assignment_infos[idx] if idx < len(assignment_infos) else [str(meth), sm, num_robots, num_tasks, nc, 0, 0, 0, 0]
-                                    writer.writerow(row_prefix + list(output_tuple))
+                                        out, copy.deepcopy(robots), copy.deepcopy(tasks),
+                                        nc, meth, grid, map_dict, sm, suitability_matrix,
+                                        max_time_steps, add_tasks, add_robots, remove_robots,
+                                        10, 10, 10, robot_generation_strict, task_generation_strict,
+                                        initial_jains_index=initial_jains,
+                                    )
+                                    row_prefix = assignment_infos[idx] if idx < len(assignment_infos) else [Run_ID, func_name(meth), sm_name, num_robots, num_tasks, nc, 0, 0, 0, 0]
+                                    writer.writerow(row_prefix + list(output_tuple) + [map_size])
+                                Run_ID += 1

--- a/hvbta/simulation/timestep.py
+++ b/hvbta/simulation/timestep.py
@@ -2,6 +2,8 @@ import random
 from typing import List, Tuple
 from hvbta.models import CapabilityProfile, TaskDescription
 from hvbta.allocators.misc_assignment import unassign_task_from_robot
+from hvbta.suitability import navigation_suitability
+
 
 def simulate_time_step(
     robots: List[CapabilityProfile],
@@ -28,51 +30,57 @@ def simulate_time_step(
     Returns:
         (tasks_completed, count, total_reward, total_success): A count of unassigned robots and the updated total reward.
     """
-    unassigned_count = 0  # Count of unassigned robots
-    tasks_completed = 0  # Count of tasks completed in this time step
+    unassigned_count = 0
+    tasks_completed = 0
 
-    # Iterate through all robots to update their positions and tasks
     for robot in robots:
-        if robot.assigned and robot.current_task is not None: # Check that all assigned robots have a task
-            # Get the assigned task
+        if robot.assigned and robot.current_task and robot.current_path:
             task = robot.current_task
 
-            # check if there is more path to traverse for the robot
+            # walk one step along the precomputed path (built by CBS upstream)
             if robot.current_path and len(robot.current_path) > 1:
-                next_position = robot.current_path[1] # gives (x, y) coordinate of next step in path
-                occupied_locations.discard(robot.location) # remove current location from occupied set
-                robot.location = next_position # update location
-                # start position for this robot should be replaced, if not then must index by ID
+                next_position = robot.current_path[1]
+                occupied_locations.discard(robot.location)
+                robot.location = next_position
                 start_positions[robot.robot_id] = next_position
-                occupied_locations.add(next_position) # update occupied set with robots new current location
-                robot.current_path.pop(0) # Move the robot one space by removing the first element from the robots path
-                robot.remaining_distance = max(0, len(robot.current_path) - 1) # recalculate the remaining distance and new location
+                occupied_locations.add(next_position)
+                robot.current_path.pop(0)
+                robot.remaining_distance = max(0, len(robot.current_path) - 1)
 
                 if robot.remaining_distance <= 1:
-                    # The robot has reached the task
                     robot.remaining_distance = 0
-                    # this wont work here because once the robot reaches the task it will just keep resetting the time on task, I put it down below after completing the task
-                    # robot.time_on_task = 0  # Reset time on task so it can begin work (time on task is a counter for how long it takes to complete a task)
 
-
-                if robot.battery_life == 0: 
-                    # print(f"Robot {robot.robot_id} failed to reach task {task.task_id} due to mechanical failure.")
-                    # get task id and task index
-                    unassign_task_from_robot(robot, tasks=tasks, unassigned_robots=unassigned_robots, unassigned_tasks=unassigned_tasks)
+                if robot.battery_life == 0:
+                    unassign_task_from_robot(robot, task, unassigned_robots=unassigned_robots, unassigned_tasks=unassigned_tasks)
                     continue
 
-            # If the robot is at the task, increment time on task
+            # at task location -> work on it
             if robot.remaining_distance == 0:
-                #robot.time_on_task += time_step
-                robot.location = task.location  # Ensure robot is at the task location
-                start_positions[robot.robot_id] = robot.location  # Update start position to task location
+                required_caps = getattr(task, "required_capabilities", None) or []
+                payload_required = None
+                for req in required_caps:
+                    if isinstance(req, str) and "payload" in req.lower():
+                        try:
+                            payload_required = float(req.split(">=")[-1].strip())
+                        except ValueError:
+                            payload_required = None
+                tools_needed = getattr(task, "tools_needed", None) or []
+                sensors_required = tools_needed[0] if len(tools_needed) > 0 and tools_needed[0] else []
+                manipulators_required = tools_needed[1] if len(tools_needed) > 1 and tools_needed[1] else []
+
+                suitability = getattr(robot, "current_task_suitability", 0.5)
+                if suitability is None:
+                    suitability = 0.5
+                suitability = max(0.0, min(1.0, suitability))
+                speed_factor = 0.5 + 1.5 * suitability  # [0.5, 2.0]
+
+                robot.location = task.location
+                start_positions[robot.robot_id] = robot.location
                 robot.battery_life -= time_step
-                task.time_left -= time_step
-                # suitability = globals()[suitability_method](robot, task)
-                # failure_probability = 1 / (100 * (suitability + 1))  # Higher suitability, lower failure rate
-                # Check if the task is completed
+                task.time_left -= time_step * speed_factor
+
+                # task completion
                 if task.time_left <= 0:
-                    # Mark task as completed
                     total_reward += task.reward
                     total_success += 1
                     task.assigned = False
@@ -80,47 +88,80 @@ def simulate_time_step(
                     robot.current_task = None
                     robot.tasks_successful += 1
                     robot.assigned = False
-                    robot.time_on_task = 0  # Reset time on task so it can begin work (time on task is a counter for how long it takes to complete a task)
+                    robot.time_on_task = 0
                     robot.current_path = []
                     robot.remaining_distance = 0
-                    # move it to unassigned robots list with check
+                    robot.current_task_suitability = None
+                    task.current_suitability = None
                     rid = robot.robot_id
                     if rid not in unassigned_robots:
                         unassigned_robots.append(rid)
-                    print(f"ROBOT {robot.robot_id} COMPLETED TASK {task.task_id}")
                     tasks_completed += 1
                     try:
                         tasks.remove(task)
                     except ValueError:
                         pass
-                elif robot.battery_life <= 0:
-                    if getattr(task, "reset_progress", False): # Only resets progress for certain tasks
+
+                # battery exhausted while working
+                if robot.battery_life <= 0:
+                    if getattr(task, "reset_progress", False):
                         task.time_left = task.time_to_complete
                     else:
                         task.time_to_complete = task.time_left
                     unassign_task_from_robot(
-                        robot, tasks=tasks, 
-                        unassigned_robots=unassigned_robots, 
-                        unassigned_tasks=unassigned_tasks
+                        robot, task,
+                        unassigned_robots=unassigned_robots,
+                        unassigned_tasks=unassigned_tasks,
                     )
 
-                elif task.performance_metrics == "safety compliance":
+                # safety-compliance stochastic failure
+                if task.performance_metrics == "safety compliance":
                     if robot.safety_features:
                         matched_safety = sum(safety in robot.safety_features for safety in task.safety_protocols)
-                        safety_score = matched_safety/max(1, len(task.safety_protocols))
+                        safety_score = matched_safety / max(1, len(task.safety_protocols))
                         if safety_score < 0.75 and (random.random() > 0.75):
                             unassign_task_from_robot(
-                                robot, tasks=tasks, 
-                                unassigned_robots=unassigned_robots, 
-                                unassigned_tasks=unassigned_tasks
+                                robot, task,
+                                unassigned_robots=unassigned_robots,
+                                unassigned_tasks=unassigned_tasks,
                             )
                     else:
                         unassign_task_from_robot(
-                            robot, tasks=tasks, 
-                            unassigned_robots=unassigned_robots, 
-                            unassigned_tasks=unassigned_tasks
+                            robot, task,
+                            unassigned_robots=unassigned_robots,
+                            unassigned_tasks=unassigned_tasks,
                         )
+
+                # runtime capability re-checks
+                if payload_required is not None and robot.payload_capacity < payload_required:
+                    unassign_task_from_robot(
+                        robot, task,
+                        unassigned_robots=unassigned_robots,
+                        unassigned_tasks=unassigned_tasks,
+                    )
+                    continue
+
+                if manipulators_required and not any(tool in robot.manipulators for tool in manipulators_required):
+                    unassign_task_from_robot(
+                        robot, task,
+                        unassigned_robots=unassigned_robots,
+                        unassigned_tasks=unassigned_tasks,
+                    )
+                    continue
+
+                nav_score = navigation_suitability(
+                    robot.mobility_type, robot.size, robot.sensor_range,
+                    task.navigation_constraints or [],
+                )
+                if nav_score == 0.0:
+                    unassign_task_from_robot(
+                        robot, task,
+                        unassigned_robots=unassigned_robots,
+                        unassigned_tasks=unassigned_tasks,
+                    )
+                    continue
+
         elif not robot.assigned:
             unassigned_count += 1
-            
+
     return tasks_completed, unassigned_count, total_reward, total_success

--- a/hvbta/suitability.py
+++ b/hvbta/suitability.py
@@ -1140,6 +1140,8 @@ def bypass_suitability_from_names_with_llm(robots, tasks, map_size=None, model=N
     content = resp["choices"][0]["message"]["content"]
 
     assigned_pairs, unassigned_robots, unassigned_tasks, parse_failed = _parse_output_matrix_bypass(content, robots, tasks)
+    print(f"ASSIGNED PAIRS: {assigned_pairs} \n UNASSIGNED ROBOTS: {unassigned_robots} \n UNASSIGNED TASKS: {unassigned_tasks}")
+
     return (assigned_pairs, unassigned_robots, unassigned_tasks), parse_failed
 
 

--- a/hvbta/suitability.py
+++ b/hvbta/suitability.py
@@ -19,6 +19,30 @@ _LLAMA_MODEL = None
 _LLAMA_REPO_ID = "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF"
 _LLAMA_FILENAME = "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
 
+# Preset configs for quick swapping; pass repo_id + filename to set_llm_model() to use a custom one.
+LLM_PRESETS = {
+    "llama-3.1-8b": ("bartowski/Meta-Llama-3.1-8B-Instruct-GGUF",
+                     "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"),
+    "qwen2.5-14b":  ("bartowski/Qwen2.5-14B-Instruct-GGUF",
+                     "Qwen2.5-14B-Instruct-Q4_K_M.gguf"),
+}
+
+def set_llm_model(preset: str = "qwen2.5-14b", repo_id: str = None, filename: str = None):
+    """
+    Swap the active LLM. Pass a preset name (see LLM_PRESETS) or repo_id+filename directly.
+    Forces the singleton to reload on next _get_llama() call.
+    """
+    global _LLAMA_MODEL, _LLAMA_REPO_ID, _LLAMA_FILENAME
+    if preset is not None:
+        if preset not in LLM_PRESETS:
+            raise ValueError(f"Unknown preset {preset!r}. Available: {list(LLM_PRESETS)}")
+        _LLAMA_REPO_ID, _LLAMA_FILENAME = LLM_PRESETS[preset]
+    elif repo_id is not None and filename is not None:
+        _LLAMA_REPO_ID, _LLAMA_FILENAME = repo_id, filename
+    else:
+        raise ValueError("Provide either preset= or both repo_id= and filename=.")
+    _LLAMA_MODEL = None  # force reload
+
 def _get_llama():
     """
     Lazy-initialize a llama.cpp Llama instance with full GPU offload.
@@ -690,17 +714,22 @@ def check_zero_suitability(assignment: List[Tuple[int, int]], suitability_matrix
     return False  # No zero suitability ratings found
 
 def calculate_suitability_matrix(
-    robots: List, 
-    tasks: List, 
+    robots: List,
+    tasks: List,
     scorer: Callable[..., object],
-    map_size: int
+    map_size: int,
 ) -> NDArray[np.float64]:
     """
     Compute suitability matrix using either:
-      • a rules based scorer (Balanced, Loose, Strict)
-      • an LLM based scorer (Llama, Mixtral)
+      - a rules based scorer (Balanced, Loose, Strict) -> returns ndarray
+      - an LLM based scorer (Llama, Qwen, ...) -> returns (ndarray, parse_failed)
+
+    The LLM scorers carry a parse-failure flag; this helper drops it so callers
+    that only want the matrix can stay shape-agnostic. Use the scorer directly
+    if you need the flag.
     """
-    M = scorer(robots, tasks, map_size=map_size)
+    result = scorer(robots, tasks, map_size=map_size)
+    M = result[0] if isinstance(result, tuple) else result
     return np.clip(M, 0.0, 1.0)
 
 def _to_jsonable(x):
@@ -777,14 +806,32 @@ def _clean_for_json(s: str) -> str:
 
     return s
 
+_LLM_LOGGER = None
+
+def _get_llm_logger():
+    """One-shot logger init; subsequent calls reuse the same handler."""
+    global _LLM_LOGGER
+    if _LLM_LOGGER is None:
+        dir_path = os.path.join('hvbta', 'io', 'logging')
+        os.makedirs(dir_path, exist_ok=True)
+        stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        log_path = os.path.join(dir_path, f"logging_{stamp}.log")
+        logger = logging.getLogger("hvbta.suitability.llm")
+        logger.setLevel(logging.DEBUG)
+        if not logger.handlers:
+            handler = logging.FileHandler(log_path, encoding='utf-8')
+            handler.setLevel(logging.DEBUG)
+            logger.addHandler(handler)
+        _LLM_LOGGER = logger
+    return _LLM_LOGGER
+
+
 def _parse_output_matrix(raw_text: str, nR: int, nT: int) -> Tuple[np.ndarray | None, bool]:
     """
     Parse the OUTPUT matrix into an (nR, nT) float array.
-    Returns None if impossible to parse.
+    Returns (matrix or None, parse_failed flag).
     """
-    dir_path = os.path.join('hvbta', 'io', 'logging')
-    logger = logging.getLogger(__name__)
-    logging.basicConfig(filename=os.path.join(dir_path, "logging_", datetime.datetime.now().strftime("%Y%m%d-%H%M%S")), encoding='utf-8', level=logging.DEBUG)
+    logger = _get_llm_logger()
 
     parse_failed = True
     block = _extract_output_matrix_text(raw_text)
@@ -856,16 +903,88 @@ def _parse_output_matrix(raw_text: str, nR: int, nT: int) -> Tuple[np.ndarray | 
     parse_failed = False
     return arr, parse_failed
 
-def _parse_output_matrix_bypass(raw_text: str) -> np.ndarray | None:
-    """Parse LLM output to get tuple of 3 lists to represent assignments
-    Tuple[List[Tuple[int, int]], List[int], List[int]]
-    Each list represents:
-        - assigned pairs of robots and tasks
-        - unassigned robots
-        - unassigned tasks
-    all represented with their robot and task IDs"""
-    # TODO: FINISH THIS FUNCTION, DIRECT ASSIGNMENT WITH LLM
-    pass
+def _parse_output_matrix_bypass(
+    raw_text: str,
+    robots: List[CapabilityProfile],
+    tasks: List[TaskDescription],
+) -> Tuple[List[Tuple[int, int]], List[int], List[int], bool]:
+    """
+    Parse a direct-assignment LLM response of the form:
+        {"assignments": [{"task_id": "<id>", "robot_id": "<id>"}, ...]}
+    into index-space assignment tuples relative to the supplied robot/task lists.
+
+    Returns:
+        (assigned_pairs, unassigned_robot_indices, unassigned_task_indices, parse_failed)
+        - assigned_pairs: list of (robot_idx, task_idx)
+        - unassigned_robot_indices / unassigned_task_indices: indices not present in any pair
+        - parse_failed: True if no usable JSON was extracted (caller should fall back)
+    """
+    logger = _get_llm_logger()
+    parse_failed = True
+
+    if not isinstance(raw_text, str):
+        return [], list(range(len(robots))), list(range(len(tasks))), parse_failed
+
+    # Pull out the first {...} block (LLM may wrap with stray text)
+    start = raw_text.find('{')
+    if start == -1:
+        logger.debug("BYPASS: no '{' in response\n%s", raw_text)
+        return [], list(range(len(robots))), list(range(len(tasks))), parse_failed
+
+    depth = 0
+    end = -1
+    for i in range(start, len(raw_text)):
+        ch = raw_text[i]
+        if ch == '{':
+            depth += 1
+        elif ch == '}':
+            depth -= 1
+            if depth == 0:
+                end = i + 1
+                break
+    if end == -1:
+        logger.debug("BYPASS: unbalanced braces\n%s", raw_text)
+        return [], list(range(len(robots))), list(range(len(tasks))), parse_failed
+
+    block = _clean_for_json(raw_text[start:end])
+    try:
+        data = json.loads(block)
+    except Exception:
+        try:
+            data = ast.literal_eval(block)
+        except Exception:
+            logger.debug("BYPASS: JSON+ast eval failed\n%s", block)
+            return [], list(range(len(robots))), list(range(len(tasks))), parse_failed
+
+    assignments = data.get("assignments", []) if isinstance(data, dict) else []
+    if not isinstance(assignments, list):
+        logger.debug("BYPASS: 'assignments' is not a list: %r", assignments)
+        return [], list(range(len(robots))), list(range(len(tasks))), parse_failed
+
+    r_idx = {r.robot_id: i for i, r in enumerate(robots)}
+    t_idx = {t.task_id: j for j, t in enumerate(tasks)}
+
+    assigned_pairs: List[Tuple[int, int]] = []
+    used_robots, used_tasks = set(), set()
+    for entry in assignments:
+        if not isinstance(entry, dict):
+            continue
+        rid = entry.get("robot_id")
+        tid = entry.get("task_id")
+        if rid not in r_idx or tid not in t_idx:
+            continue
+        ri, ti = r_idx[rid], t_idx[tid]
+        # one robot per task, one task per robot - first valid pair wins
+        if ri in used_robots or ti in used_tasks:
+            continue
+        assigned_pairs.append((ri, ti))
+        used_robots.add(ri)
+        used_tasks.add(ti)
+
+    unassigned_robots = [i for i in range(len(robots)) if i not in used_robots]
+    unassigned_tasks = [j for j in range(len(tasks)) if j not in used_tasks]
+    parse_failed = False
+    return assigned_pairs, unassigned_robots, unassigned_tasks, parse_failed
 
 
 def build_name_only_prompt(robots_json: str, tasks_json: str) -> str:
@@ -937,7 +1056,7 @@ def _task_name_view(t: TaskDescription) -> dict:
         d["nl_description"] = desc
     return d
 
-def evaluate_suitability_from_names_with_llm(robots: List[CapabilityProfile], tasks: List[TaskDescription], model=_LLAMA_FILENAME) -> np.ndarray:
+def evaluate_suitability_from_names_with_llm(robots: List[CapabilityProfile], tasks: List[TaskDescription], map_size=None, model=None) -> np.ndarray:
     """
     Evaluate suitability of robots for tasks using a local GGUF-quantized Llama model
     via llama.cpp with full GPU offload. Returns an (R, T) float array in [0,1].
@@ -949,7 +1068,6 @@ def evaluate_suitability_from_names_with_llm(robots: List[CapabilityProfile], ta
     Returns:
         M: An (R, T) numpy array of float suitability scores in [0,1].
     """
-    evaluate_suitability_from_names_with_llm._is_llm_batch = True
     llm = _get_llama()
 
     R = [_to_jsonable(_robot_min_view(r)) for r in robots]
@@ -970,23 +1088,23 @@ def evaluate_suitability_from_names_with_llm(robots: List[CapabilityProfile], ta
     )
     content = resp["choices"][0]["message"]["content"]
 
-    M, M.parse_failed = _parse_output_matrix(content, nR=len(robots), nT=len(tasks))
+    M, parse_failed = _parse_output_matrix(content, nR=len(robots), nT=len(tasks))
     if M is None:
-        M = np.full((len(robots), len(tasks)), 0.0, dtype=float)
-    return M
+        M = np.zeros((len(robots), len(tasks)), dtype=float)
+    return M, parse_failed
 
-def bypass_suitability_from_names_with_llm(robots, tasks, model=_LLAMA_FILENAME) -> np.ndarray:
+def bypass_suitability_from_names_with_llm(robots, tasks, map_size=None, model=None):
     """
-    One-shot assignment variant using the local GGUF-quantized Llama model via
-    llama.cpp with full GPU offload. Returns an (R, T) float array in [0,1].
-    Parameters:
-        robots: List of CapabilityProfile objects.
-        tasks: List of TaskDescription objects.
-        model: The GGUF filename (held in the module-level singleton).
+    One-shot direct-assignment variant: the LLM returns (robot_id, task_id) pairs
+    instead of a suitability matrix. Skips the scoring/voting layer entirely.
+
     Returns:
-        M: An (R, T) numpy array of float suitability scores in [0,1].
+        ((assigned_pairs, unassigned_robot_idx, unassigned_task_idx), parse_failed)
+        - assigned_pairs:           list[(robot_idx, task_idx)]
+        - unassigned_robot_idx:     list[int]
+        - unassigned_task_idx:      list[int]
+        - parse_failed:             bool, True if the LLM response wasn't parseable
     """
-    evaluate_suitability_from_names_with_llm._is_llm_batch = True
     llm = _get_llama()
 
     R = [_to_jsonable(_robot_min_view(r)) for r in robots]
@@ -1021,7 +1139,13 @@ def bypass_suitability_from_names_with_llm(robots, tasks, model=_LLAMA_FILENAME)
     )
     content = resp["choices"][0]["message"]["content"]
 
-    M, M.parse_failed = _parse_output_matrix(content, nR=len(robots), nT=len(tasks))
-    if M is None:
-        M = np.full((len(robots), len(tasks)), 0.0, dtype=float)
-    return M
+    assigned_pairs, unassigned_robots, unassigned_tasks, parse_failed = _parse_output_matrix_bypass(content, robots, tasks)
+    return (assigned_pairs, unassigned_robots, unassigned_tasks), parse_failed
+
+
+# Mark LLM scorers at module scope so callers can detect them via getattr(fn, "_is_llm_batch", False)
+# before the first call (used by the LLM cache + the matrix/tuple dispatch in calculate_suitability_matrix).
+evaluate_suitability_from_names_with_llm._is_llm_batch = True
+bypass_suitability_from_names_with_llm._is_llm_batch = True
+# Direct-assignment LLM bypasses the suitability-matrix layer entirely.
+bypass_suitability_from_names_with_llm._is_llm_direct = True


### PR DESCRIPTION
- fixed a logging path crash for the LLMs
- fixed `M, M.parse_failed` bug (ndarrays don't have attributes, used separate bool instead)
- added Qwen 2.5 14B Instruct to the LLMs we can use, in my experience its better than Llama 3.1 8B
- added guard for task and robot spawning that follows the rules:
1. robot start locations cannot overlap
2. robot goal locations (tasks) cannot overlap
3. robot start and goal locations MAY overlap

- Implemented direct assignment, this involved multiple steps:
1. new `_parse_output_matrix_bypass()` function for parsing the direct assignment LLM output and creating a list of assigned pairs, unassigned robots, and unassigned tasks
2. new `bypass_suitability_from_names_with_llm()` function for one shot direct assignment
3. new `reassign_robots_to_tasks_direct()` function that does direct robot reassignment
5. all baked into the main simulation with logging

- removed `_is_llm_batch` flags from inside LLM function bodies because that sets the flag too late giving us a stale LLM cache, added them to the module scope for `suitability.py` and added a new flag for direct assignment with LLM
- NOTE: direct assignment and LLM suitability must be run together because direct assignment uses the LLM_cache for its scoring