### PR TITLE
Early termination voting, urgent pressure, urgent task tracking, robot added tracking

### DIFF
--- a/hvbta/allocators/voting.py
+++ b/hvbta/allocators/voting.py
@@ -258,44 +258,67 @@ def rank_assignments_condorcet_method(assignments: List[List[Tuple[int, int]]], 
     return pairwise_wins, ranked_assignments
 
 def assign_tasks_with_voting(
-        robots: List[CapabilityProfile], 
-        tasks: List[TaskDescription], 
-        suitability_matrix: np.ndarray, 
-        num_candidates: int, 
-        voting_method: Callable
+        robots: List[CapabilityProfile],
+        tasks: List[TaskDescription],
+        suitability_matrix: np.ndarray,
+        num_candidates: int,
+        voting_method: Callable,
+        score_threshold: float = None,
+        time_budget_ms: float = None,
         ) -> Tuple[Tuple[List[Tuple[int, int]], List[int], List[int]], float, float, List[float]]:
     """
     Assigns tasks to robots using random assignment and ranks the assignments using the specified voting method.
-    
+
     Parameters:
         robots: List of robot profiles.
         tasks: List of task descriptions.
         suitability_matrix: A 2D numpy array with suitability scores for each robot-task pair.
-        num_candidates: Number of candidate assignments to generate.
+        num_candidates: Upper bound on candidate assignments to generate.
         voting_method: The name of the voting function.
-    
+        score_threshold: If not None, a float in [0, 1]. Stop generating
+            candidates once one has mean-per-pair suitability >= this value.
+            Because every suitability path clamps to [0, 1], threshold=0.7
+            means "candidate averages 0.7 suitability per pair" and is
+            tunable across runs regardless of num_pairs.
+        time_budget_ms: If not None, stop generating candidates once wall-clock
+            elapsed (from function entry) reaches this many milliseconds.
+        When both are None, behavior matches the previous full-pool version.
+
     Returns:
         (best_assignment, best_score, length, per_agent_scores): The best assignment, its suitability score, and the time taken for the voting process.
     """
     num_robots = len(robots)
     num_tasks = len(tasks)
-    
-    random_assignments = generate_random_assignments(num_robots, num_tasks, num_candidates)
-    # def map_with_jv(S_mat):
-    #     pairs = jv_task_allocation(S_mat)  # adjust to match your JV return
-    #     return pairs
 
-    # candidate_assignments = generate_candidates_perturb_and_map(
-    #     S=suitability_matrix,
-    #     K=num_candidates,
-    #     solve_fn=map_with_jv,
-    #     noise="gumbel",
-    #     scale=0.10,
-    #     anneal=True,
-    #     seed=None
-    # )
-    
     start = time.perf_counter_ns()
+
+    # Anytime candidate accumulation. Generate one at a time so we can bail on
+    # either budget. If neither is provided, this loops num_candidates times
+    # identically to the old batch-generate behavior.
+    random_assignments = []
+    for _ in range(num_candidates):
+        one = generate_random_assignments(num_robots, num_tasks, 1)[0]
+        random_assignments.append(one)
+
+        if score_threshold is not None:
+            # Cheap per-candidate score = mean-per-pair suitability across
+            # every pair in the candidate (zeros pull it down, penalizing
+            # candidates with many unusable assignments). Because per-pair
+            # suitability is clamped to [0, 1] at every scorer, this mean is
+            # in [0, 1] too - a threshold of 0.7 means "candidate averages
+            # 0.7 suitability per pair" and is tunable across runs.
+            pairs = one[0]
+            if pairs:
+                candidate_score = sum(suitability_matrix[r][t] for r, t in pairs) / len(pairs)
+            else:
+                candidate_score = 0.0
+            if candidate_score >= score_threshold:
+                break
+        if time_budget_ms is not None:
+            if (time.perf_counter_ns() - start) / 1e6 >= time_budget_ms:
+                break
+
+    # Run the voting rule on whatever pool we accumulated (>= 1 candidate).
     total_scores, assignment_ranking = voting_method(random_assignments, suitability_matrix)
     end = time.perf_counter_ns()
     length = (end - start) / 1000.0
@@ -304,7 +327,7 @@ def assign_tasks_with_voting(
     # check for zero suitability in the best assignment and move to the next best if so
     while(check_zero_suitability(random_assignments[assignment_ranking[best_ranking]][0], suitability_matrix) and best_ranking < len(assignment_ranking)-1):
         best_ranking += 1
-    if best_ranking == num_candidates-1:
+    if best_ranking == len(random_assignments) - 1:
         best_ranking = 0
 
     best_assignment = random_assignments[assignment_ranking[best_ranking]]
@@ -423,17 +446,19 @@ def assign_tasks_randomly(
     return filtered_best_assignments, total_scores, length, per_agent_scores
 
 def reassign_robots_to_tasks(
-        robots: List[CapabilityProfile], 
-        tasks: List[TaskDescription], 
-        num_candidates: int, 
-        voting_method: Callable, 
+        robots: List[CapabilityProfile],
+        tasks: List[TaskDescription],
+        num_candidates: int,
+        voting_method: Callable,
         suitability_source,  # Can be Callable (scorer) OR tuple (matrix, r_idx, t_idx) for LLM
-        unassigned_robots: List[str], 
-        unassigned_tasks: List[str], 
-        start_positions: dict, 
+        unassigned_robots: List[str],
+        unassigned_tasks: List[str],
+        start_positions: dict,
         goal_positions: dict,
         map_size: int,
-        inertia_threshold: float = 0.1):
+        inertia_threshold: float = 0.1,
+        score_threshold: float = None,
+        time_budget_ms: float = None):
     """
     Reassigns unassigned robots to unassigned tasks using a voting method.
     Parameters:
@@ -480,7 +505,8 @@ def reassign_robots_to_tasks(
         output, score, length, per_agent_scores = reassign_robots_to_tasks_randomly(robots, tasks, num_candidates, unassigned_robots, unassigned_tasks)
     else:
         output, score, length, per_agent_scores = assign_tasks_with_voting(
-            urobots, utasks, suitability_matrix, num_candidates, voting_method)
+            urobots, utasks, suitability_matrix, num_candidates, voting_method,
+            score_threshold=score_threshold, time_budget_ms=time_budget_ms)
 
     # this assigned_pairs only contains the unassigned robots and tasks, I may have to pass in the actual assigned_pairs to update it
     assigned_pairs = output[0] # list of tuples

--- a/hvbta/simulation/main_simulation.py
+++ b/hvbta/simulation/main_simulation.py
@@ -417,6 +417,16 @@ def main_simulation(
     completed_per_step = []
     pending_event_steps = []
     adaptation_latencies = []
+    # Urgency accounting. At each replan tick we record:
+    #   percentage_urgent_per_replan: fraction of currently-unassigned tasks
+    #     whose priority_level == "urgent". Cross-run comparable in [0, 1].
+    #   robot_pressure_per_replan:    1 if the "add robots" event fired in the
+    #     same tick as this replan, else 0. Cross-run comparable in [0, 1] when
+    #     averaged.
+    # Report mean + max of each at run end so runs can be bucketed by
+    # ("none urgent, no pressure") ... ("all urgent, high pressure").
+    percentage_urgent_per_replan = []
+    robot_pressure_per_replan = []
 
     # Full-schedule denominators. Constant across all methods in a (rep, sm) group
     # regardless of which method terminated early. Use these as denominators when
@@ -639,6 +649,20 @@ def main_simulation(
             should_replan_cbs = True
 
         if should_replan:
+            # ---- urgency + pressure snapshot for this replan ----
+            # Compute once so voting/optimization/direct-LLM all see the same
+            # numbers and downstream analysis can bucket runs by these dimensions.
+            unassigned_task_objs = [t for t in tasks if not t.assigned]
+            num_unassigned = len(unassigned_task_objs)
+            num_urgent = sum(
+                1 for t in unassigned_task_objs
+                if getattr(t, "priority_level", "medium") == "urgent"
+            )
+            percentage_urgent = (num_urgent / num_unassigned) if num_unassigned else 0.0
+            robot_pressure = 1.0 if events["new_robots"] > 0 else 0.0
+            percentage_urgent_per_replan.append(percentage_urgent)
+            robot_pressure_per_replan.append(robot_pressure)
+
             # determine what to pass to the reassignment functions
             if getattr(suitability_method, "_is_llm_batch", False):
                 current_robot_ids = {r.robot_id for r in robots}
@@ -667,11 +691,20 @@ def main_simulation(
 
             # assign with voting
             if voting_method in voting_methods:
-                print(f"REASSIGNING WITH VOTING METHOD: {voting_method_name}")
+                # Anytime pressure: any urgent unassigned task or a new-robot
+                # event this tick triggers a tight budget so voting bails on
+                # the first good-enough candidate.
+                urgent_pressure = (percentage_urgent > 0.0) or (robot_pressure > 0.0) # here I c
+                voting_budget_ms = 20.0 if urgent_pressure else None
+                voting_score_threshold = 0.7 if urgent_pressure else None
+                print(f"REASSIGNING WITH VOTING METHOD: {voting_method_name}"
+                      f"{f' (URGENT: pct_urgent={percentage_urgent:.0%}, robot_pressure={int(robot_pressure)}, 20ms budget, 0.7 threshold)' if urgent_pressure else ''}")
                 total_reassignments += 1
                 _, unassigned_robots, unassigned_tasks, reassign_score, reassign_length, reassign_per_agent_scores = V.reassign_robots_to_tasks(
                     robots, tasks, num_candidates, voting_method, suitability_source,
                     unassigned_robots, unassigned_tasks, start_positions, goal_positions, HYPOTENUSE,
+                    time_budget_ms=voting_budget_ms,
+                    score_threshold=voting_score_threshold,
                 )
                 if reassign_per_agent_scores:
                     reassignment_jains_indices.append(calculate_jains_index(reassign_per_agent_scores))
@@ -757,6 +790,14 @@ def main_simulation(
     adaptation_latency_max = float(max(adaptation_latencies)) if adaptation_latencies else 0.0
     task_success_counts = [r.tasks_successful for r in robots]
     workload_variance = float(np.var(task_success_counts)) if task_success_counts else 0.0
+    # Urgency + pressure summaries. Bucketing key for downstream analysis:
+    #   "none urgent, no pressure"    -> Percentage_Urgent_Mean == 0 AND Robot_Pressure_Fraction == 0
+    #   "some urgent, no pressure"    -> Percentage_Urgent_Mean > 0  AND Robot_Pressure_Fraction == 0
+    #   "none urgent, some pressure"  -> Percentage_Urgent_Mean == 0 AND Robot_Pressure_Fraction > 0
+    #   "all urgent, high pressure"   -> Percentage_Urgent_Mean == 1 AND Robot_Pressure_Fraction > 0
+    percentage_urgent_mean = float(np.mean(percentage_urgent_per_replan)) if percentage_urgent_per_replan else 0.0
+    percentage_urgent_max = float(max(percentage_urgent_per_replan)) if percentage_urgent_per_replan else 0.0
+    robot_pressure_fraction = float(np.mean(robot_pressure_per_replan)) if robot_pressure_per_replan else 0.0
 
     print(f"Voting: "
           f"Task completion fraction: {task_completion_fraction:.2%} ({total_success}/{total_tasks} spawned), "
@@ -765,6 +806,8 @@ def main_simulation(
           f"Throughput: mean={throughput_mean:.3f}/step var={throughput_var:.3f}, "
           f"Adaptation latency: mean={adaptation_latency_mean:.2f} max={adaptation_latency_max:.0f} (over {len(adaptation_latencies)} events), "
           f"Workload variance: {workload_variance:.3f}, "
+          f"Urgency mean={percentage_urgent_mean:.2%} max={percentage_urgent_max:.2%}, "
+          f"Robot-pressure fraction={robot_pressure_fraction:.2%}, "
           f"Reassignment Time: {total_reassignment_time}, "
           f"Reassignment quality: {cumulative_reassignment_quality}, reassignments: {total_reassignments}, "
           f"Robots: {len(robots)}")
@@ -784,6 +827,8 @@ def main_simulation(
         workload_variance,
         # Section 7 - full-schedule denominators, constant across methods in a (rep, sm) group.
         full_schedule_tasks_spawned, full_schedule_robots_max,
+        # Section 8 - urgency + pressure summaries.
+        percentage_urgent_mean, percentage_urgent_max, robot_pressure_fraction,
     ) + avg_reassign_metrics[1:]  # skip first (Jains) - already exposed above
 
 
@@ -964,6 +1009,8 @@ if __name__ == "__main__":
                 'Workload_Variance',
                 # Full-schedule denominators, constant across methods in a (rep, sm) group.
                 'Full_Schedule_Tasks_Spawned', 'Full_Schedule_Robots_Max',
+                # Urgency + pressure bucketing keys.
+                'Percentage_Urgent_Mean', 'Percentage_Urgent_Max', 'Robot_Pressure_Fraction',
                 # Reassignment fairness (trimmed to 3 canonical values; Jains already exposed above)
                 'Avg_Reass_Gini', 'Avg_Reass_Median', 'Avg_Reass_IQR',
                 # Overhead + config


### PR DESCRIPTION
Added early termination to voting, score threshold the candidate score must meet to terminate early and not see all candidates, also added urgent pressure which tracks if any new robots were added or any unassigned tasks are urgent, this assigns a time limit for voting to terminate early. The system tracks urgent task percentage (mean and max) and robot pressure (added robots) and reports it to the CSV to test when higher pressure causing earlier termination makes voting better than optimization.